### PR TITLE
New neighbourhood records

### DIFF
--- a/data/144/483/751/3/1444837513.geojson
+++ b/data/144/483/751/3/1444837513.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
     "wof:geomhash":"8ff1dab45ffef8d8040b159286bdc12e",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444837513,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444837513,
-    "wof:lastmodified":1566335077,
+    "wof:lastmodified":1566339017,
     "wof:name":"Hlidar",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],

--- a/data/144/483/751/3/1444837513.geojson
+++ b/data/144/483/751/3/1444837513.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837513,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.9088283701,64.132382831,-21.9088283701,64.132382831",
+    "geom:latitude":64.132383,
+    "geom:longitude":-21.908828,
+    "iso:country":"IS",
+    "lbl:latitude":64.132383,
+    "lbl:longitude":-21.908828,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Hlidar"
+    ],
+    "name:isl_x_preferred":[
+        "Hl\u00ed\u00f0ar"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"8ff1dab45ffef8d8040b159286bdc12e",
+    "wof:hierarchy":[],
+    "wof:id":1444837513,
+    "wof:lastmodified":1566335077,
+    "wof:name":"Hlidar",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.90882837006373,
+    64.13238283101596,
+    -21.90882837006373,
+    64.13238283101596
+],
+  "geometry": {"coordinates":[-21.90882837006373,64.13238283101596],"type":"Point"}
+}

--- a/data/144/483/752/5/1444837525.geojson
+++ b/data/144/483/752/5/1444837525.geojson
@@ -1,0 +1,57 @@
+{
+  "id": 1444837525,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.9520870588,64.1490044901,-21.9520870588,64.1490044901",
+    "geom:latitude":64.149004,
+    "geom:longitude":-21.952087,
+    "iso:country":"IS",
+    "lbl:latitude":64.149004,
+    "lbl:longitude":-21.952087,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":12.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Vesturbaer"
+    ],
+    "name:isl_x_preferred":[
+        "Vesturb\u00e6r"
+    ],
+    "name:isl_x_variant":[
+        "Gamli Vesturb\u00e6rinn"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"1736d6689892c536e18a07514ea2c490",
+    "wof:hierarchy":[],
+    "wof:id":1444837525,
+    "wof:lastmodified":1566335077,
+    "wof:name":"Vesturbaer",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.952087058821615,
+    64.1490044900939,
+    -21.952087058821615,
+    64.1490044900939
+],
+  "geometry": {"coordinates":[-21.95208705882161,64.1490044900939],"type":"Point"}
+}

--- a/data/144/483/752/5/1444837525.geojson
+++ b/data/144/483/752/5/1444837525.geojson
@@ -32,15 +32,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
-    "wof:geomhash":"1736d6689892c536e18a07514ea2c490",
-    "wof:hierarchy":[],
+    "wof:geomhash":"f243cb9ac70828a1a7f04529a7e3a565",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444837525,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444837525,
-    "wof:lastmodified":1566335077,
+    "wof:lastmodified":1566339018,
     "wof:name":"Vesturbaer",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],
@@ -48,9 +61,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -21.952087058821615,
+    -21.95208705882161,
     64.1490044900939,
-    -21.952087058821615,
+    -21.95208705882161,
     64.1490044900939
 ],
   "geometry": {"coordinates":[-21.95208705882161,64.1490044900939],"type":"Point"}

--- a/data/144/483/753/9/1444837539.geojson
+++ b/data/144/483/753/9/1444837539.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
     "wof:geomhash":"439d43a668f2f5c0999c3da47a0970a1",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444837539,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444837539,
-    "wof:lastmodified":1566335077,
+    "wof:lastmodified":1566339021,
     "wof:name":"Midborg",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],

--- a/data/144/483/753/9/1444837539.geojson
+++ b/data/144/483/753/9/1444837539.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837539,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.9356075583,64.1389727926,-21.9356075583,64.1389727926",
+    "geom:latitude":64.138973,
+    "geom:longitude":-21.935608,
+    "iso:country":"IS",
+    "lbl:latitude":64.138973,
+    "lbl:longitude":-21.935607,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":15.0,
+    "mz:min_zoom":12.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Midborg"
+    ],
+    "name:isl_x_preferred":[
+        "Mi\u00f0borg"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"439d43a668f2f5c0999c3da47a0970a1",
+    "wof:hierarchy":[],
+    "wof:id":1444837539,
+    "wof:lastmodified":1566335077,
+    "wof:name":"Midborg",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.93560755834242,
+    64.13897279261442,
+    -21.93560755834242,
+    64.13897279261442
+],
+  "geometry": {"coordinates":[-21.93560755834242,64.13897279261442],"type":"Point"}
+}

--- a/data/144/483/755/3/1444837553.geojson
+++ b/data/144/483/755/3/1444837553.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837553,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.8733516676,64.1416183143,-21.8733516676,64.1416183143",
+    "geom:latitude":64.141618,
+    "geom:longitude":-21.873352,
+    "iso:country":"IS",
+    "lbl:latitude":64.141618,
+    "lbl:longitude":-21.873351,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":12.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Laugardalur"
+    ],
+    "name:isl_x_preferred":[
+        "Laugardalur"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"c4b4facb2af970289a3edec777a5b815",
+    "wof:hierarchy":[],
+    "wof:id":1444837553,
+    "wof:lastmodified":1566335077,
+    "wof:name":"Laugardalur",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.873351667643245,
+    64.14161831425483,
+    -21.873351667643245,
+    64.14161831425483
+],
+  "geometry": {"coordinates":[-21.87335166764325,64.14161831425483],"type":"Point"}
+}

--- a/data/144/483/755/3/1444837553.geojson
+++ b/data/144/483/755/3/1444837553.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
-    "wof:geomhash":"c4b4facb2af970289a3edec777a5b815",
-    "wof:hierarchy":[],
+    "wof:geomhash":"6cbc3571202871c3dca6596553fad4d8",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444837553,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444837553,
-    "wof:lastmodified":1566335077,
+    "wof:lastmodified":1566339021,
     "wof:name":"Laugardalur",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -21.873351667643245,
+    -21.87335166764325,
     64.14161831425483,
-    -21.873351667643245,
+    -21.87335166764325,
     64.14161831425483
 ],
   "geometry": {"coordinates":[-21.87335166764325,64.14161831425483],"type":"Point"}

--- a/data/144/483/756/1/1444837561.geojson
+++ b/data/144/483/756/1/1444837561.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837561,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.8777004247,64.1245427415,-21.8777004247,64.1245427415",
+    "geom:latitude":64.124543,
+    "geom:longitude":-21.8777,
+    "iso:country":"IS",
+    "lbl:latitude":64.124543,
+    "lbl:longitude":-21.8777,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":15.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Haaleiti og Bustadir"
+    ],
+    "name:isl_x_preferred":[
+        "H\u00e1aleiti og B\u00fasta\u00f0ir"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"f6c5af9efa850e180119550f5be04330",
+    "wof:hierarchy":[],
+    "wof:id":1444837561,
+    "wof:lastmodified":1566335077,
+    "wof:name":"Haaleiti og Bustadir",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.87770042471415,
+    64.1245427415316,
+    -21.87770042471415,
+    64.1245427415316
+],
+  "geometry": {"coordinates":[-21.87770042471415,64.1245427415316],"type":"Point"}
+}

--- a/data/144/483/756/1/1444837561.geojson
+++ b/data/144/483/756/1/1444837561.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
     "wof:geomhash":"f6c5af9efa850e180119550f5be04330",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444837561,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444837561,
-    "wof:lastmodified":1566335077,
+    "wof:lastmodified":1566339022,
     "wof:name":"Haaleiti og Bustadir",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],

--- a/data/144/483/756/9/1444837569.geojson
+++ b/data/144/483/756/9/1444837569.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837569,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.8323817984,64.1033584495,-21.8323817984,64.1033584495",
+    "geom:latitude":64.103358,
+    "geom:longitude":-21.832382,
+    "iso:country":"IS",
+    "lbl:latitude":64.103358,
+    "lbl:longitude":-21.832381,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":15.0,
+    "mz:min_zoom":12.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Breidholt"
+    ],
+    "name:isl_x_preferred":[
+        "Brei\u00f0holt"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"d4f9f37eda2e2297cc62d05915fc7058",
+    "wof:hierarchy":[],
+    "wof:id":1444837569,
+    "wof:lastmodified":1566335077,
+    "wof:name":"Breidholt",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.832381798396362,
+    64.10335844952398,
+    -21.832381798396362,
+    64.10335844952398
+],
+  "geometry": {"coordinates":[-21.83238179839636,64.10335844952398],"type":"Point"}
+}

--- a/data/144/483/756/9/1444837569.geojson
+++ b/data/144/483/756/9/1444837569.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
-    "wof:geomhash":"d4f9f37eda2e2297cc62d05915fc7058",
-    "wof:hierarchy":[],
+    "wof:geomhash":"e04b80739e39f7795e17c7a85f410301",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444837569,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444837569,
-    "wof:lastmodified":1566335077,
+    "wof:lastmodified":1566339023,
     "wof:name":"Breidholt",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -21.832381798396362,
+    -21.83238179839636,
     64.10335844952398,
-    -21.832381798396362,
+    -21.83238179839636,
     64.10335844952398
 ],
   "geometry": {"coordinates":[-21.83238179839636,64.10335844952398],"type":"Point"}

--- a/data/144/483/757/7/1444837577.geojson
+++ b/data/144/483/757/7/1444837577.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
     "wof:geomhash":"c10e08aa3d88d786b9e0524d8dec9f00",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444837577,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444837577,
-    "wof:lastmodified":1566335077,
+    "wof:lastmodified":1566339025,
     "wof:name":"Arbaer",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],

--- a/data/144/483/757/7/1444837577.geojson
+++ b/data/144/483/757/7/1444837577.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837577,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.7978206238,64.1168503133,-21.7978206238,64.1168503133",
+    "geom:latitude":64.11685,
+    "geom:longitude":-21.797821,
+    "iso:country":"IS",
+    "lbl:latitude":64.11685,
+    "lbl:longitude":-21.79782,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Arbaer"
+    ],
+    "name:isl_x_preferred":[
+        "\u00c1rb\u00e6r"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"c10e08aa3d88d786b9e0524d8dec9f00",
+    "wof:hierarchy":[],
+    "wof:id":1444837577,
+    "wof:lastmodified":1566335077,
+    "wof:name":"Arbaer",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.79782062378028,
+    64.11685031330315,
+    -21.79782062378028,
+    64.11685031330315
+],
+  "geometry": {"coordinates":[-21.79782062378028,64.11685031330315],"type":"Point"}
+}

--- a/data/144/483/758/9/1444837589.geojson
+++ b/data/144/483/758/9/1444837589.geojson
@@ -29,13 +29,25 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
     "wof:geomhash":"b9b7354739b2a74d5f2bddd90c7cffae",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":-1,
+            "neighbourhood_id":1444837589,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444837589,
-    "wof:lastmodified":1566335077,
+    "wof:lastmodified":1566339026,
     "wof:name":"Kjalarnes",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/144/483/758/9/1444837589.geojson
+++ b/data/144/483/758/9/1444837589.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837589,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.7861476443,64.224748822,-21.7861476443,64.224748822",
+    "geom:latitude":64.224749,
+    "geom:longitude":-21.786148,
+    "iso:country":"IS",
+    "lbl:latitude":64.224749,
+    "lbl:longitude":-21.786147,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":14.0,
+    "mz:min_zoom":12.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Kjalarnes"
+    ],
+    "name:isl_x_preferred":[
+        "Kjalarnes"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"b9b7354739b2a74d5f2bddd90c7cffae",
+    "wof:hierarchy":[],
+    "wof:id":1444837589,
+    "wof:lastmodified":1566335077,
+    "wof:name":"Kjalarnes",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.78614764427418,
+    64.22474882195385,
+    -21.78614764427418,
+    64.22474882195385
+],
+  "geometry": {"coordinates":[-21.78614764427418,64.22474882195385],"type":"Point"}
+}

--- a/data/144/483/760/1/1444837601.geojson
+++ b/data/144/483/760/1/1444837601.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837601,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.7506709419,64.1307351354,-21.7506709419,64.1307351354",
+    "geom:latitude":64.130735,
+    "geom:longitude":-21.750671,
+    "iso:country":"IS",
+    "lbl:latitude":64.130735,
+    "lbl:longitude":-21.75067,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":14.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Grafarholt og Ulfarsardalur"
+    ],
+    "name:isl_x_preferred":[
+        "Grafarholt og \u00dalfars\u00e1rdalur"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"e2b5a8f74d427612a569dbc450fba6ed",
+    "wof:hierarchy":[],
+    "wof:id":1444837601,
+    "wof:lastmodified":1566335077,
+    "wof:name":"Grafarholt og Ulfarsardalur",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.750670941853702,
+    64.13073513542292,
+    -21.750670941853702,
+    64.13073513542292
+],
+  "geometry": {"coordinates":[-21.7506709418537,64.13073513542292],"type":"Point"}
+}

--- a/data/144/483/760/1/1444837601.geojson
+++ b/data/144/483/760/1/1444837601.geojson
@@ -29,13 +29,25 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
-    "wof:geomhash":"e2b5a8f74d427612a569dbc450fba6ed",
-    "wof:hierarchy":[],
+    "wof:geomhash":"d228e643577b9ac5e35a6b0b1f9dfed3",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":-1,
+            "neighbourhood_id":1444837601,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444837601,
-    "wof:lastmodified":1566335077,
+    "wof:lastmodified":1566339027,
     "wof:name":"Grafarholt og Ulfarsardalur",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
@@ -45,9 +57,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -21.750670941853702,
+    -21.7506709418537,
     64.13073513542292,
-    -21.750670941853702,
+    -21.7506709418537,
     64.13073513542292
 ],
   "geometry": {"coordinates":[-21.7506709418537,64.13073513542292],"type":"Point"}

--- a/data/144/483/761/1/1444837611.geojson
+++ b/data/144/483/761/1/1444837611.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
-    "wof:geomhash":"cc5aa99bb41e148f47efe1bcc6bd038c",
-    "wof:hierarchy":[],
+    "wof:geomhash":"2c8df36594c8d02adb06a9d3d1109f81",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444837611,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444837611,
-    "wof:lastmodified":1566335077,
+    "wof:lastmodified":1566339027,
     "wof:name":"Grandar",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -21.969997071495193,
+    -21.96999707149519,
     64.14922903898602,
-    -21.969997071495193,
+    -21.96999707149519,
     64.14922903898602
 ],
   "geometry": {"coordinates":[-21.96999707149519,64.14922903898602],"type":"Point"}

--- a/data/144/483/761/1/1444837611.geojson
+++ b/data/144/483/761/1/1444837611.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837611,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.9699970715,64.149229039,-21.9699970715,64.149229039",
+    "geom:latitude":64.149229,
+    "geom:longitude":-21.969997,
+    "iso:country":"IS",
+    "lbl:latitude":64.149229,
+    "lbl:longitude":-21.969997,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Grandar"
+    ],
+    "name:isl_x_preferred":[
+        "Grandar"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"cc5aa99bb41e148f47efe1bcc6bd038c",
+    "wof:hierarchy":[],
+    "wof:id":1444837611,
+    "wof:lastmodified":1566335077,
+    "wof:name":"Grandar",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.969997071495193,
+    64.14922903898602,
+    -21.969997071495193,
+    64.14922903898602
+],
+  "geometry": {"coordinates":[-21.96999707149519,64.14922903898602],"type":"Point"}
+}

--- a/data/144/483/762/3/1444837623.geojson
+++ b/data/144/483/762/3/1444837623.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837623,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.9463077896,64.1566630766,-21.9463077896,64.1566630766",
+    "geom:latitude":64.156663,
+    "geom:longitude":-21.946308,
+    "iso:country":"IS",
+    "lbl:latitude":64.156663,
+    "lbl:longitude":-21.946307,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Orfirisey"
+    ],
+    "name:isl_x_preferred":[
+        "\u00d6rfirisey"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"647cdde35146284b102de4c5629fcae2",
+    "wof:hierarchy":[],
+    "wof:id":1444837623,
+    "wof:lastmodified":1566335077,
+    "wof:name":"Orfirisey",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.94630778955635,
+    64.15666307664858,
+    -21.94630778955635,
+    64.15666307664858
+],
+  "geometry": {"coordinates":[-21.94630778955635,64.15666307664858],"type":"Point"}
+}

--- a/data/144/483/762/3/1444837623.geojson
+++ b/data/144/483/762/3/1444837623.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
     "wof:geomhash":"647cdde35146284b102de4c5629fcae2",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444837623,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444837623,
-    "wof:lastmodified":1566335077,
+    "wof:lastmodified":1566339030,
     "wof:name":"Orfirisey",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],

--- a/data/144/483/763/3/1444837633.geojson
+++ b/data/144/483/763/3/1444837633.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
-    "wof:geomhash":"daee15d6c64258dedd31e1077280ca2e",
-    "wof:hierarchy":[],
+    "wof:geomhash":"45cf72c9549522e3f7576d2471a26ec6",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444837633,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444837633,
-    "wof:lastmodified":1566335077,
+    "wof:lastmodified":1566339031,
     "wof:name":"Skjol",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -21.971942568079545,
+    -21.97194256807954,
     64.14528669447637,
-    -21.971942568079545,
+    -21.97194256807954,
     64.14528669447637
 ],
   "geometry": {"coordinates":[-21.97194256807954,64.14528669447637],"type":"Point"}

--- a/data/144/483/763/3/1444837633.geojson
+++ b/data/144/483/763/3/1444837633.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837633,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.9719425681,64.1452866945,-21.9719425681,64.1452866945",
+    "geom:latitude":64.145287,
+    "geom:longitude":-21.971943,
+    "iso:country":"IS",
+    "lbl:latitude":64.145287,
+    "lbl:longitude":-21.971942,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Skjol"
+    ],
+    "name:isl_x_preferred":[
+        "Skj\u00f3l"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"daee15d6c64258dedd31e1077280ca2e",
+    "wof:hierarchy":[],
+    "wof:id":1444837633,
+    "wof:lastmodified":1566335077,
+    "wof:name":"Skjol",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.971942568079545,
+    64.14528669447637,
+    -21.971942568079545,
+    64.14528669447637
+],
+  "geometry": {"coordinates":[-21.97194256807954,64.14528669447637],"type":"Point"}
+}

--- a/data/144/483/764/5/1444837645.geojson
+++ b/data/144/483/764/5/1444837645.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
-    "wof:geomhash":"c15a45837cf66a408d337904a763b30c",
-    "wof:hierarchy":[],
+    "wof:geomhash":"87b6f497ad3c0243691af9e2827f97fa",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444837645,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444837645,
-    "wof:lastmodified":1566335077,
+    "wof:lastmodified":1566339032,
     "wof:name":"Melar",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -21.958896296866847,
+    -21.95889629686685,
     64.14443826866382,
-    -21.958896296866847,
+    -21.95889629686685,
     64.14443826866382
 ],
   "geometry": {"coordinates":[-21.95889629686685,64.14443826866382],"type":"Point"}

--- a/data/144/483/764/5/1444837645.geojson
+++ b/data/144/483/764/5/1444837645.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837645,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.9588962969,64.1444382687,-21.9588962969,64.1444382687",
+    "geom:latitude":64.144438,
+    "geom:longitude":-21.958896,
+    "iso:country":"IS",
+    "lbl:latitude":64.144438,
+    "lbl:longitude":-21.958896,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Melar"
+    ],
+    "name:isl_x_preferred":[
+        "Melar"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"c15a45837cf66a408d337904a763b30c",
+    "wof:hierarchy":[],
+    "wof:id":1444837645,
+    "wof:lastmodified":1566335077,
+    "wof:name":"Melar",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.958896296866847,
+    64.14443826866382,
+    -21.958896296866847,
+    64.14443826866382
+],
+  "geometry": {"coordinates":[-21.95889629686685,64.14443826866382],"type":"Point"}
+}

--- a/data/144/483/765/7/1444837657.geojson
+++ b/data/144/483/765/7/1444837657.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
-    "wof:geomhash":"ec755f68f41c4175ece12c06862d5a39",
-    "wof:hierarchy":[],
+    "wof:geomhash":"9914f3f68afc092080a7ff18a78159e0",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444837657,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444837657,
-    "wof:lastmodified":1566335077,
+    "wof:lastmodified":1566339032,
     "wof:name":"Hagar",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -21.959840434915133,
+    -21.95984043491513,
     64.140233189976,
-    -21.959840434915133,
+    -21.95984043491513,
     64.140233189976
 ],
   "geometry": {"coordinates":[-21.95984043491513,64.140233189976],"type":"Point"}

--- a/data/144/483/765/7/1444837657.geojson
+++ b/data/144/483/765/7/1444837657.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837657,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.9598404349,64.14023319,-21.9598404349,64.14023319",
+    "geom:latitude":64.140233,
+    "geom:longitude":-21.95984,
+    "iso:country":"IS",
+    "lbl:latitude":64.140233,
+    "lbl:longitude":-21.95984,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Hagar"
+    ],
+    "name:isl_x_preferred":[
+        "Hagar"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"ec755f68f41c4175ece12c06862d5a39",
+    "wof:hierarchy":[],
+    "wof:id":1444837657,
+    "wof:lastmodified":1566335077,
+    "wof:name":"Hagar",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.959840434915133,
+    64.140233189976,
+    -21.959840434915133,
+    64.140233189976
+],
+  "geometry": {"coordinates":[-21.95984043491513,64.140233189976],"type":"Point"}
+}

--- a/data/144/483/766/7/1444837667.geojson
+++ b/data/144/483/766/7/1444837667.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837667,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.9465366715,64.1527217879,-21.9465366715,64.1527217879",
+    "geom:latitude":64.152722,
+    "geom:longitude":-21.946537,
+    "iso:country":"IS",
+    "lbl:latitude":64.152722,
+    "lbl:longitude":-21.946536,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Vesturhofn"
+    ],
+    "name:isl_x_preferred":[
+        "Vesturh\u00f6fn"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"e6ce8c7cfbc823fa010883a0be0eb675",
+    "wof:hierarchy":[],
+    "wof:id":1444837667,
+    "wof:lastmodified":1566335077,
+    "wof:name":"Vesturhofn",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.946536671507452,
+    64.1527217878816,
+    -21.946536671507452,
+    64.1527217878816
+],
+  "geometry": {"coordinates":[-21.94653667150745,64.1527217878816],"type":"Point"}
+}

--- a/data/144/483/766/7/1444837667.geojson
+++ b/data/144/483/766/7/1444837667.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
-    "wof:geomhash":"e6ce8c7cfbc823fa010883a0be0eb675",
-    "wof:hierarchy":[],
+    "wof:geomhash":"261772fd1e703dba7f555b7e1209f75b",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444837667,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444837667,
-    "wof:lastmodified":1566335077,
+    "wof:lastmodified":1566339035,
     "wof:name":"Vesturhofn",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -21.946536671507452,
+    -21.94653667150745,
     64.1527217878816,
-    -21.946536671507452,
+    -21.94653667150745,
     64.1527217878816
 ],
   "geometry": {"coordinates":[-21.94653667150745,64.1527217878816],"type":"Point"}

--- a/data/144/483/767/9/1444837679.geojson
+++ b/data/144/483/767/9/1444837679.geojson
@@ -32,15 +32,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
     "wof:geomhash":"18c5f0e29e630c8abeef57fb775c2d70",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444837679,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444837679,
-    "wof:lastmodified":1566335077,
+    "wof:lastmodified":1566339036,
     "wof:name":"Skerjafjordur",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],

--- a/data/144/483/767/9/1444837679.geojson
+++ b/data/144/483/767/9/1444837679.geojson
@@ -1,0 +1,57 @@
+{
+  "id": 1444837679,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.9544330988,64.1291122346,-21.9544330988,64.1291122346",
+    "geom:latitude":64.129112,
+    "geom:longitude":-21.954433,
+    "iso:country":"IS",
+    "lbl:latitude":64.129112,
+    "lbl:longitude":-21.954433,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Skerjafjordur"
+    ],
+    "name:isl_x_preferred":[
+        "Skerjafj\u00f6r\u00f0ur"
+    ],
+    "name:isl_x_variant":[
+        "Skildinganes"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"18c5f0e29e630c8abeef57fb775c2d70",
+    "wof:hierarchy":[],
+    "wof:id":1444837679,
+    "wof:lastmodified":1566335077,
+    "wof:name":"Skerjafjordur",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.9544330988204,
+    64.12911223459066,
+    -21.9544330988204,
+    64.12911223459066
+],
+  "geometry": {"coordinates":[-21.9544330988204,64.12911223459066],"type":"Point"}
+}

--- a/data/144/483/769/1/1444837691.geojson
+++ b/data/144/483/769/1/1444837691.geojson
@@ -26,15 +26,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
     "wof:geomhash":"508c062a7821a7713df83dfeb11aa42d",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444837691,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444837691,
-    "wof:lastmodified":1566335077,
+    "wof:lastmodified":1566339037,
     "wof:name":"Litli Skerjafjordur",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],

--- a/data/144/483/769/1/1444837691.geojson
+++ b/data/144/483/769/1/1444837691.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444837691,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.9532886891,64.1350040235,-21.9532886891,64.1350040235",
+    "geom:latitude":64.135004,
+    "geom:longitude":-21.953289,
+    "iso:country":"IS",
+    "lbl:latitude":64.135004,
+    "lbl:longitude":-21.953288,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Litli Skerjafjordur"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"508c062a7821a7713df83dfeb11aa42d",
+    "wof:hierarchy":[],
+    "wof:id":1444837691,
+    "wof:lastmodified":1566335077,
+    "wof:name":"Litli Skerjafjordur",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.9532886890649,
+    64.13500402347393,
+    -21.9532886890649,
+    64.13500402347393
+],
+  "geometry": {"coordinates":[-21.9532886890649,64.13500402347393],"type":"Point"}
+}

--- a/data/144/483/769/9/1444837699.geojson
+++ b/data/144/483/769/9/1444837699.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837699,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.948939932,64.1388979099,-21.948939932,64.1388979099",
+    "geom:latitude":64.138898,
+    "geom:longitude":-21.94894,
+    "iso:country":"IS",
+    "lbl:latitude":64.138898,
+    "lbl:longitude":-21.948939,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Haskoli"
+    ],
+    "name:isl_x_preferred":[
+        "H\u00e1sk\u00f3li"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"82d071d01583c0e7e9529a3b499d37dd",
+    "wof:hierarchy":[],
+    "wof:id":1444837699,
+    "wof:lastmodified":1566335077,
+    "wof:name":"Haskoli",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.948939931994,
+    64.13889790988081,
+    -21.948939931994,
+    64.13889790988081
+],
+  "geometry": {"coordinates":[-21.948939931994,64.13889790988081],"type":"Point"}
+}

--- a/data/144/483/769/9/1444837699.geojson
+++ b/data/144/483/769/9/1444837699.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
     "wof:geomhash":"82d071d01583c0e7e9529a3b499d37dd",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444837699,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444837699,
-    "wof:lastmodified":1566335077,
+    "wof:lastmodified":1566339037,
     "wof:name":"Haskoli",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],

--- a/data/144/483/771/1/1444837711.geojson
+++ b/data/144/483/771/1/1444837711.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
-    "wof:geomhash":"797415598289437dacc1111889e4911f",
-    "wof:hierarchy":[],
+    "wof:geomhash":"ec644292b31305dbdcfb5f1fa8218528",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444837711,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444837711,
-    "wof:lastmodified":1566335078,
+    "wof:lastmodified":1566339040,
     "wof:name":"Midbaer",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -21.940671571510517,
+    -21.94067157151052,
     64.14756359169554,
-    -21.940671571510517,
+    -21.94067157151052,
     64.14756359169554
 ],
   "geometry": {"coordinates":[-21.94067157151052,64.14756359169554],"type":"Point"}

--- a/data/144/483/771/1/1444837711.geojson
+++ b/data/144/483/771/1/1444837711.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837711,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.9406715715,64.1475635917,-21.9406715715,64.1475635917",
+    "geom:latitude":64.147564,
+    "geom:longitude":-21.940672,
+    "iso:country":"IS",
+    "lbl:latitude":64.147564,
+    "lbl:longitude":-21.940671,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":16.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Midbaer"
+    ],
+    "name:isl_x_preferred":[
+        "Mi\u00f0b\u00e6r"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"797415598289437dacc1111889e4911f",
+    "wof:hierarchy":[],
+    "wof:id":1444837711,
+    "wof:lastmodified":1566335078,
+    "wof:name":"Midbaer",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.940671571510517,
+    64.14756359169554,
+    -21.940671571510517,
+    64.14756359169554
+],
+  "geometry": {"coordinates":[-21.94067157151052,64.14756359169554],"type":"Point"}
+}

--- a/data/144/483/772/1/1444837721.geojson
+++ b/data/144/483/772/1/1444837721.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
     "wof:geomhash":"21899aa89506c6b08a2b64279a1ad969",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444837721,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444837721,
-    "wof:lastmodified":1566335078,
+    "wof:lastmodified":1566339041,
     "wof:name":"Austurbaer",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],

--- a/data/144/483/772/1/1444837721.geojson
+++ b/data/144/483/772/1/1444837721.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837721,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.9284549974,64.1437395456,-21.9284549974,64.1437395456",
+    "geom:latitude":64.14374,
+    "geom:longitude":-21.928455,
+    "iso:country":"IS",
+    "lbl:latitude":64.143739,
+    "lbl:longitude":-21.928454,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":16.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Austurbaer"
+    ],
+    "name:isl_x_preferred":[
+        "Austurb\u00e6r"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"21899aa89506c6b08a2b64279a1ad969",
+    "wof:hierarchy":[],
+    "wof:id":1444837721,
+    "wof:lastmodified":1566335078,
+    "wof:name":"Austurbaer",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.92845499737056,
+    64.14373954558724,
+    -21.92845499737056,
+    64.14373954558724
+],
+  "geometry": {"coordinates":[-21.92845499737056,64.14373954558724],"type":"Point"}
+}

--- a/data/144/483/773/5/1444837735.geojson
+++ b/data/144/483/773/5/1444837735.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
-    "wof:geomhash":"e0073dad13013728f5f630cb6a92e506",
-    "wof:hierarchy":[],
+    "wof:geomhash":"9300907f870a1e585c0b9cf44398ad9f",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444837735,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444837735,
-    "wof:lastmodified":1566335078,
+    "wof:lastmodified":1566339041,
     "wof:name":"Vatnsmyri",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -21.931373242247087,
+    -21.93137324224709,
     64.1298862627482,
-    -21.931373242247087,
+    -21.93137324224709,
     64.1298862627482
 ],
   "geometry": {"coordinates":[-21.93137324224709,64.1298862627482],"type":"Point"}

--- a/data/144/483/773/5/1444837735.geojson
+++ b/data/144/483/773/5/1444837735.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837735,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.9313732422,64.1298862627,-21.9313732422,64.1298862627",
+    "geom:latitude":64.129886,
+    "geom:longitude":-21.931373,
+    "iso:country":"IS",
+    "lbl:latitude":64.129886,
+    "lbl:longitude":-21.931373,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Vatnsmyri"
+    ],
+    "name:isl_x_preferred":[
+        "Vatnsm\u00fdri"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"e0073dad13013728f5f630cb6a92e506",
+    "wof:hierarchy":[],
+    "wof:id":1444837735,
+    "wof:lastmodified":1566335078,
+    "wof:name":"Vatnsmyri",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.931373242247087,
+    64.1298862627482,
+    -21.931373242247087,
+    64.1298862627482
+],
+  "geometry": {"coordinates":[-21.93137324224709,64.1298862627482],"type":"Point"}
+}

--- a/data/144/483/774/5/1444837745.geojson
+++ b/data/144/483/774/5/1444837745.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837745,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.9195858218,64.1280385961,-21.9195858218,64.1280385961",
+    "geom:latitude":64.128039,
+    "geom:longitude":-21.919586,
+    "iso:country":"IS",
+    "lbl:latitude":64.128039,
+    "lbl:longitude":-21.919585,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Oskjuhlid"
+    ],
+    "name:isl_x_preferred":[
+        "\u00d6skjuhl\u00ed\u00f0"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"3e06c6ec765ce3619913448406b9733d",
+    "wof:hierarchy":[],
+    "wof:id":1444837745,
+    "wof:lastmodified":1566335078,
+    "wof:name":"Oskjuhlid",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.919585821765434,
+    64.1280385961073,
+    -21.919585821765434,
+    64.1280385961073
+],
+  "geometry": {"coordinates":[-21.91958582176543,64.1280385961073],"type":"Point"}
+}

--- a/data/144/483/774/5/1444837745.geojson
+++ b/data/144/483/774/5/1444837745.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
-    "wof:geomhash":"3e06c6ec765ce3619913448406b9733d",
-    "wof:hierarchy":[],
+    "wof:geomhash":"daad3d0c06142ed93bc4b8d1c61501af",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444837745,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444837745,
-    "wof:lastmodified":1566335078,
+    "wof:lastmodified":1566339042,
     "wof:name":"Oskjuhlid",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -21.919585821765434,
+    -21.91958582176543,
     64.1280385961073,
-    -21.919585821765434,
+    -21.91958582176543,
     64.1280385961073
 ],
   "geometry": {"coordinates":[-21.91958582176543,64.1280385961073],"type":"Point"}

--- a/data/144/483/775/5/1444837755.geojson
+++ b/data/144/483/775/5/1444837755.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837755,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.9187847349,64.1390227049,-21.9187847349,64.1390227049",
+    "geom:latitude":64.139023,
+    "geom:longitude":-21.918785,
+    "iso:country":"IS",
+    "lbl:latitude":64.139023,
+    "lbl:longitude":-21.918784,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Nordurmyri"
+    ],
+    "name:isl_x_preferred":[
+        "Nor\u00f0urm\u00fdri"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"fc5ef7465956e68cb92c89b8cf77db68",
+    "wof:hierarchy":[],
+    "wof:id":1444837755,
+    "wof:lastmodified":1566335078,
+    "wof:name":"Nordurmyri",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.91878473493659,
+    64.13902270490392,
+    -21.91878473493659,
+    64.13902270490392
+],
+  "geometry": {"coordinates":[-21.91878473493659,64.13902270490392],"type":"Point"}
+}

--- a/data/144/483/775/5/1444837755.geojson
+++ b/data/144/483/775/5/1444837755.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
     "wof:geomhash":"fc5ef7465956e68cb92c89b8cf77db68",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444837755,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444837755,
-    "wof:lastmodified":1566335078,
+    "wof:lastmodified":1566339045,
     "wof:name":"Nordurmyri",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],

--- a/data/144/483/776/9/1444837769.geojson
+++ b/data/144/483/776/9/1444837769.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
-    "wof:geomhash":"06a0d6dd3106df809feff1faab8d5a01",
-    "wof:hierarchy":[],
+    "wof:geomhash":"31a1ef2d65444aa3e5de45b313ae1e61",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444837769,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444837769,
-    "wof:lastmodified":1566335078,
+    "wof:lastmodified":1566339046,
     "wof:name":"Holt",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -21.905509581772794,
+    -21.90550958177279,
     64.14017079280654,
-    -21.905509581772794,
+    -21.90550958177279,
     64.14017079280654
 ],
   "geometry": {"coordinates":[-21.90550958177279,64.14017079280654],"type":"Point"}

--- a/data/144/483/776/9/1444837769.geojson
+++ b/data/144/483/776/9/1444837769.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837769,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.9055095818,64.1401707928,-21.9055095818,64.1401707928",
+    "geom:latitude":64.140171,
+    "geom:longitude":-21.90551,
+    "iso:country":"IS",
+    "lbl:latitude":64.140171,
+    "lbl:longitude":-21.905509,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Holt"
+    ],
+    "name:isl_x_preferred":[
+        "Holt"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"06a0d6dd3106df809feff1faab8d5a01",
+    "wof:hierarchy":[],
+    "wof:id":1444837769,
+    "wof:lastmodified":1566335078,
+    "wof:name":"Holt",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.905509581772794,
+    64.14017079280654,
+    -21.905509581772794,
+    64.14017079280654
+],
+  "geometry": {"coordinates":[-21.90550958177279,64.14017079280654],"type":"Point"}
+}

--- a/data/144/483/777/5/1444837775.geojson
+++ b/data/144/483/777/5/1444837775.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
-    "wof:geomhash":"c0b5262c9c124201bbc1933cbe4b5408",
-    "wof:hierarchy":[],
+    "wof:geomhash":"5795c98e3b4603f97eab458b981c7a0d",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444837775,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444837775,
-    "wof:lastmodified":1566335078,
+    "wof:lastmodified":1566339046,
     "wof:name":"Tun",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -21.903163541774013,
+    -21.90316354177401,
     64.14482505423491,
-    -21.903163541774013,
+    -21.90316354177401,
     64.14482505423491
 ],
   "geometry": {"coordinates":[-21.90316354177401,64.14482505423491],"type":"Point"}

--- a/data/144/483/777/5/1444837775.geojson
+++ b/data/144/483/777/5/1444837775.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837775,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.9031635418,64.1448250542,-21.9031635418,64.1448250542",
+    "geom:latitude":64.144825,
+    "geom:longitude":-21.903164,
+    "iso:country":"IS",
+    "lbl:latitude":64.144825,
+    "lbl:longitude":-21.903163,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Tun"
+    ],
+    "name:isl_x_preferred":[
+        "T\u00fan"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"c0b5262c9c124201bbc1933cbe4b5408",
+    "wof:hierarchy":[],
+    "wof:id":1444837775,
+    "wof:lastmodified":1566335078,
+    "wof:name":"Tun",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.903163541774013,
+    64.14482505423491,
+    -21.903163541774013,
+    64.14482505423491
+],
+  "geometry": {"coordinates":[-21.90316354177401,64.14482505423491],"type":"Point"}
+}

--- a/data/144/483/778/5/1444837785.geojson
+++ b/data/144/483/778/5/1444837785.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837785,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.9127765837,64.1423295687,-21.9127765837,64.1423295687",
+    "geom:latitude":64.14233,
+    "geom:longitude":-21.912777,
+    "iso:country":"IS",
+    "lbl:latitude":64.14233,
+    "lbl:longitude":-21.912776,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Hlemmur"
+    ],
+    "name:isl_x_preferred":[
+        "Hlemmur"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"7065fc2cda5af74729eea77eaf6359b9",
+    "wof:hierarchy":[],
+    "wof:id":1444837785,
+    "wof:lastmodified":1566335078,
+    "wof:name":"Hlemmur",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.912776583720213,
+    64.14232956869988,
+    -21.912776583720213,
+    64.14232956869988
+],
+  "geometry": {"coordinates":[-21.91277658372021,64.14232956869988],"type":"Point"}
+}

--- a/data/144/483/778/5/1444837785.geojson
+++ b/data/144/483/778/5/1444837785.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
-    "wof:geomhash":"7065fc2cda5af74729eea77eaf6359b9",
-    "wof:hierarchy":[],
+    "wof:geomhash":"d9d2e6517acbb7f32519f95d739c8559",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444837785,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444837785,
-    "wof:lastmodified":1566335078,
+    "wof:lastmodified":1566339047,
     "wof:name":"Hlemmur",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -21.912776583720213,
+    -21.91277658372021,
     64.14232956869988,
-    -21.912776583720213,
+    -21.91277658372021,
     64.14232956869988
 ],
   "geometry": {"coordinates":[-21.91277658372021,64.14232956869988],"type":"Point"}

--- a/data/144/483/779/5/1444837795.geojson
+++ b/data/144/483/779/5/1444837795.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837795,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.9390407876,64.149865251,-21.9390407876,64.149865251",
+    "geom:latitude":64.149865,
+    "geom:longitude":-21.939041,
+    "iso:country":"IS",
+    "lbl:latitude":64.149865,
+    "lbl:longitude":-21.93904,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Austurhofn"
+    ],
+    "name:isl_x_preferred":[
+        "Austurh\u00f6fn"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"e027716ecd54f4ccaa27819e7f3a7188",
+    "wof:hierarchy":[],
+    "wof:id":1444837795,
+    "wof:lastmodified":1566335078,
+    "wof:name":"Austurhofn",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.939040787608928,
+    64.1498652509836,
+    -21.939040787608928,
+    64.1498652509836
+],
+  "geometry": {"coordinates":[-21.93904078760893,64.14986525098359],"type":"Point"}
+}

--- a/data/144/483/779/5/1444837795.geojson
+++ b/data/144/483/779/5/1444837795.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
-    "wof:geomhash":"e027716ecd54f4ccaa27819e7f3a7188",
-    "wof:hierarchy":[],
+    "wof:geomhash":"12adba620cdd485b41037e4a6dcf76e0",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444837795,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444837795,
-    "wof:lastmodified":1566335078,
+    "wof:lastmodified":1566339050,
     "wof:name":"Austurhofn",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -21.939040787608928,
+    -21.93904078760893,
     64.1498652509836,
-    -21.939040787608928,
+    -21.93904078760893,
     64.1498652509836
 ],
   "geometry": {"coordinates":[-21.93904078760893,64.14986525098359],"type":"Point"}

--- a/data/144/483/780/5/1444837805.geojson
+++ b/data/144/483/780/5/1444837805.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
     "wof:geomhash":"b0e63d5f355a14e623bb65d690643510",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444837805,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444837805,
-    "wof:lastmodified":1566335078,
+    "wof:lastmodified":1566339051,
     "wof:name":"Bradraedisholt",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],

--- a/data/144/483/780/5/1444837805.geojson
+++ b/data/144/483/780/5/1444837805.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837805,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.962296475,64.1496312397,-21.962296475,64.1496312397",
+    "geom:latitude":64.149631,
+    "geom:longitude":-21.962296,
+    "iso:country":"IS",
+    "lbl:latitude":64.149631,
+    "lbl:longitude":-21.962296,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Bradraedisholt"
+    ],
+    "name:isl_x_preferred":[
+        "Br\u00e1\u00f0r\u00e6\u00f0isholt"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"b0e63d5f355a14e623bb65d690643510",
+    "wof:hierarchy":[],
+    "wof:id":1444837805,
+    "wof:lastmodified":1566335078,
+    "wof:name":"Bradraedisholt",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.96229647495747,
+    64.14963123966814,
+    -21.96229647495747,
+    64.14963123966814
+],
+  "geometry": {"coordinates":[-21.96229647495747,64.14963123966814],"type":"Point"}
+}

--- a/data/144/483/781/1/1444837811.geojson
+++ b/data/144/483/781/1/1444837811.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837811,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.9567603928,64.1379399778,-21.9567603928,64.1379399778",
+    "geom:latitude":64.13794,
+    "geom:longitude":-21.95676,
+    "iso:country":"IS",
+    "lbl:latitude":64.13794,
+    "lbl:longitude":-21.95676,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Grimsstadaholt"
+    ],
+    "name:isl_x_preferred":[
+        "Gr\u00edmssta\u00f0aholt"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"ec6b0fc365502d685e143d3a18a2802d",
+    "wof:hierarchy":[],
+    "wof:id":1444837811,
+    "wof:lastmodified":1566335078,
+    "wof:name":"Grimsstadaholt",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.95676039276525,
+    64.13793997782311,
+    -21.95676039276525,
+    64.13793997782311
+],
+  "geometry": {"coordinates":[-21.95676039276525,64.13793997782311],"type":"Point"}
+}

--- a/data/144/483/781/1/1444837811.geojson
+++ b/data/144/483/781/1/1444837811.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
     "wof:geomhash":"ec6b0fc365502d685e143d3a18a2802d",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444837811,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444837811,
-    "wof:lastmodified":1566335078,
+    "wof:lastmodified":1566339051,
     "wof:name":"Grimsstadaholt",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],

--- a/data/144/483/782/1/1444837821.geojson
+++ b/data/144/483/782/1/1444837821.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
-    "wof:geomhash":"d6bab259798e0afd6db6b74f4980f25b",
-    "wof:hierarchy":[],
+    "wof:geomhash":"fe81d16abfd3f971e6c299e4d8b7efd4",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444837821,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444837821,
-    "wof:lastmodified":1566335078,
+    "wof:lastmodified":1566339052,
     "wof:name":"Tjarnarbrekka",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -21.944400767405845,
+    -21.94440076740585,
     64.14594471891266,
-    -21.944400767405845,
+    -21.94440076740585,
     64.14594471891266
 ],
   "geometry": {"coordinates":[-21.94440076740585,64.14594471891266],"type":"Point"}

--- a/data/144/483/782/1/1444837821.geojson
+++ b/data/144/483/782/1/1444837821.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837821,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.9444007674,64.1459447189,-21.9444007674,64.1459447189",
+    "geom:latitude":64.145945,
+    "geom:longitude":-21.944401,
+    "iso:country":"IS",
+    "lbl:latitude":64.145945,
+    "lbl:longitude":-21.9444,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Tjarnarbrekka"
+    ],
+    "name:isl_x_preferred":[
+        "Tjarnarbrekka"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"d6bab259798e0afd6db6b74f4980f25b",
+    "wof:hierarchy":[],
+    "wof:id":1444837821,
+    "wof:lastmodified":1566335078,
+    "wof:name":"Tjarnarbrekka",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.944400767405845,
+    64.14594471891266,
+    -21.944400767405845,
+    64.14594471891266
+],
+  "geometry": {"coordinates":[-21.94440076740585,64.14594471891266],"type":"Point"}
+}

--- a/data/144/483/782/9/1444837829.geojson
+++ b/data/144/483/782/9/1444837829.geojson
@@ -1,0 +1,57 @@
+{
+  "id": 1444837829,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.93912933,64.1480001238,-21.93912933,64.1480001238",
+    "geom:latitude":64.148,
+    "geom:longitude":-21.939129,
+    "iso:country":"IS",
+    "lbl:latitude":64.148,
+    "lbl:longitude":-21.939129,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Kvosin"
+    ],
+    "name:isl_x_preferred":[
+        "Kvosin"
+    ],
+    "name:isl_x_variant":[
+        "V\u00edkin"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"44b65a2047c101a64853eac0d03f551c",
+    "wof:hierarchy":[],
+    "wof:id":1444837829,
+    "wof:lastmodified":1566335078,
+    "wof:name":"Kvosin",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.939129329969575,
+    64.14800012377562,
+    -21.939129329969575,
+    64.14800012377562
+],
+  "geometry": {"coordinates":[-21.93912932996957,64.14800012377562],"type":"Point"}
+}

--- a/data/144/483/782/9/1444837829.geojson
+++ b/data/144/483/782/9/1444837829.geojson
@@ -32,15 +32,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
-    "wof:geomhash":"44b65a2047c101a64853eac0d03f551c",
-    "wof:hierarchy":[],
+    "wof:geomhash":"a67cf904c52613aba19fd57f1f296282",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444837829,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444837829,
-    "wof:lastmodified":1566335078,
+    "wof:lastmodified":1566339055,
     "wof:name":"Kvosin",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],
@@ -48,9 +61,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -21.939129329969575,
+    -21.93912932996957,
     64.14800012377562,
-    -21.939129329969575,
+    -21.93912932996957,
     64.14800012377562
 ],
   "geometry": {"coordinates":[-21.93912932996957,64.14800012377562],"type":"Point"}

--- a/data/144/483/783/9/1444837839.geojson
+++ b/data/144/483/783/9/1444837839.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
     "wof:geomhash":"e490652d408345a364b290f290439b49",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444837839,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444837839,
-    "wof:lastmodified":1566335078,
+    "wof:lastmodified":1566339056,
     "wof:name":"Arnarholl",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],

--- a/data/144/483/783/9/1444837839.geojson
+++ b/data/144/483/783/9/1444837839.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837839,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.9275278761,64.1472952525,-21.9275278761,64.1472952525",
+    "geom:latitude":64.147295,
+    "geom:longitude":-21.927528,
+    "iso:country":"IS",
+    "lbl:latitude":64.147295,
+    "lbl:longitude":-21.927527,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Arnarholl"
+    ],
+    "name:isl_x_preferred":[
+        "Arnarh\u00f3ll"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"e490652d408345a364b290f290439b49",
+    "wof:hierarchy":[],
+    "wof:id":1444837839,
+    "wof:lastmodified":1566335078,
+    "wof:name":"Arnarholl",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.9275278760732,
+    64.14729525245396,
+    -21.9275278760732,
+    64.14729525245396
+],
+  "geometry": {"coordinates":[-21.9275278760732,64.14729525245396],"type":"Point"}
+}

--- a/data/144/483/784/7/1444837847.geojson
+++ b/data/144/483/784/7/1444837847.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
     "wof:geomhash":"2998a0b33a01c5503452d22e3979395f",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444837847,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444837847,
-    "wof:lastmodified":1566335078,
+    "wof:lastmodified":1566339056,
     "wof:name":"Skuggahverfi",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],

--- a/data/144/483/784/7/1444837847.geojson
+++ b/data/144/483/784/7/1444837847.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837847,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.9200749075,64.1456484037,-21.9200749075,64.1456484037",
+    "geom:latitude":64.145648,
+    "geom:longitude":-21.920075,
+    "iso:country":"IS",
+    "lbl:latitude":64.145648,
+    "lbl:longitude":-21.920074,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Skuggahverfi"
+    ],
+    "name:isl_x_preferred":[
+        "Skuggahverfi"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"2998a0b33a01c5503452d22e3979395f",
+    "wof:hierarchy":[],
+    "wof:id":1444837847,
+    "wof:lastmodified":1566335078,
+    "wof:name":"Skuggahverfi",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.92007490754051,
+    64.14564840368955,
+    -21.92007490754051,
+    64.14564840368955
+],
+  "geometry": {"coordinates":[-21.92007490754051,64.14564840368955],"type":"Point"}
+}

--- a/data/144/483/785/7/1444837857.geojson
+++ b/data/144/483/785/7/1444837857.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837857,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.9387573968,64.1430032603,-21.9387573968,64.1430032603",
+    "geom:latitude":64.143003,
+    "geom:longitude":-21.938757,
+    "iso:country":"IS",
+    "lbl:latitude":64.143003,
+    "lbl:longitude":-21.938757,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Laufas"
+    ],
+    "name:isl_x_preferred":[
+        "Lauf\u00e1s"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"ba2f655504fdcc66d75ade13fef071ec",
+    "wof:hierarchy":[],
+    "wof:id":1444837857,
+    "wof:lastmodified":1566335078,
+    "wof:name":"Laufas",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.938757396799037,
+    64.14300326032915,
+    -21.938757396799037,
+    64.14300326032915
+],
+  "geometry": {"coordinates":[-21.93875739679904,64.14300326032915],"type":"Point"}
+}

--- a/data/144/483/785/7/1444837857.geojson
+++ b/data/144/483/785/7/1444837857.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
-    "wof:geomhash":"ba2f655504fdcc66d75ade13fef071ec",
-    "wof:hierarchy":[],
+    "wof:geomhash":"136d12ee3347b7d6b8b4b234b0c4d119",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444837857,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444837857,
-    "wof:lastmodified":1566335078,
+    "wof:lastmodified":1566339057,
     "wof:name":"Laufas",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -21.938757396799037,
+    -21.93875739679904,
     64.14300326032915,
-    -21.938757396799037,
+    -21.93875739679904,
     64.14300326032915
 ],
   "geometry": {"coordinates":[-21.93875739679904,64.14300326032915],"type":"Point"}

--- a/data/144/483/786/3/1444837863.geojson
+++ b/data/144/483/786/3/1444837863.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837863,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.9314617846,64.1400833284,-21.9314617846,64.1400833284",
+    "geom:latitude":64.140083,
+    "geom:longitude":-21.931462,
+    "iso:country":"IS",
+    "lbl:latitude":64.140083,
+    "lbl:longitude":-21.931461,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Spitalahlid"
+    ],
+    "name:isl_x_preferred":[
+        "Sp\u00edtalahl\u00ed\u00f0"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"8be57309fb3dd75d248e463e1d49c3fb",
+    "wof:hierarchy":[],
+    "wof:id":1444837863,
+    "wof:lastmodified":1566335078,
+    "wof:name":"Spitalahlid",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.931461784607727,
+    64.14008332838144,
+    -21.931461784607727,
+    64.14008332838144
+],
+  "geometry": {"coordinates":[-21.93146178460773,64.14008332838144],"type":"Point"}
+}

--- a/data/144/483/786/3/1444837863.geojson
+++ b/data/144/483/786/3/1444837863.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
-    "wof:geomhash":"8be57309fb3dd75d248e463e1d49c3fb",
-    "wof:hierarchy":[],
+    "wof:geomhash":"0f3d8a4367542adf7d15dd957561fe5f",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444837863,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444837863,
-    "wof:lastmodified":1566335078,
+    "wof:lastmodified":1566339060,
     "wof:name":"Spitalahlid",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -21.931461784607727,
+    -21.93146178460773,
     64.14008332838144,
-    -21.931461784607727,
+    -21.93146178460773,
     64.14008332838144
 ],
   "geometry": {"coordinates":[-21.93146178460773,64.14008332838144],"type":"Point"}

--- a/data/144/483/787/3/1444837873.geojson
+++ b/data/144/483/787/3/1444837873.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837873,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.9364113568,64.1454799705,-21.9364113568,64.1454799705",
+    "geom:latitude":64.14548,
+    "geom:longitude":-21.936411,
+    "iso:country":"IS",
+    "lbl:latitude":64.14548,
+    "lbl:longitude":-21.936411,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Thingholt"
+    ],
+    "name:isl_x_preferred":[
+        "\u00deingholt"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"5ef758ac737f9aeb55dd3b2e0b05e423",
+    "wof:hierarchy":[],
+    "wof:id":1444837873,
+    "wof:lastmodified":1566335078,
+    "wof:name":"Thingholt",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.936411356800264,
+    64.14547997046883,
+    -21.936411356800264,
+    64.14547997046883
+],
+  "geometry": {"coordinates":[-21.93641135680026,64.14547997046883],"type":"Point"}
+}

--- a/data/144/483/787/3/1444837873.geojson
+++ b/data/144/483/787/3/1444837873.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
-    "wof:geomhash":"5ef758ac737f9aeb55dd3b2e0b05e423",
-    "wof:hierarchy":[],
+    "wof:geomhash":"e8d3663780814a8469dc67836165c567",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444837873,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444837873,
-    "wof:lastmodified":1566335078,
+    "wof:lastmodified":1566339061,
     "wof:name":"Thingholt",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -21.936411356800264,
+    -21.93641135680026,
     64.14547997046883,
-    -21.936411356800264,
+    -21.93641135680026,
     64.14547997046883
 ],
   "geometry": {"coordinates":[-21.93641135680026,64.14547997046883],"type":"Point"}

--- a/data/144/483/788/3/1444837883.geojson
+++ b/data/144/483/788/3/1444837883.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
-    "wof:geomhash":"955b76313fd59b208c5dab3548c42de7",
-    "wof:hierarchy":[],
+    "wof:geomhash":"b34da3779bc4581b6dc8ef8db76da6a1",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444837883,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444837883,
-    "wof:lastmodified":1566335078,
+    "wof:lastmodified":1566339061,
     "wof:name":"Asgardur",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -21.930789443876375,
+    -21.93078944387637,
     64.14319042498293,
-    -21.930789443876375,
+    -21.93078944387637,
     64.14319042498293
 ],
   "geometry": {"coordinates":[-21.93078944387637,64.14319042498293],"type":"Point"}

--- a/data/144/483/788/3/1444837883.geojson
+++ b/data/144/483/788/3/1444837883.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837883,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.9307894439,64.143190425,-21.9307894439,64.143190425",
+    "geom:latitude":64.14319,
+    "geom:longitude":-21.930789,
+    "iso:country":"IS",
+    "lbl:latitude":64.14319,
+    "lbl:longitude":-21.930789,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Asgardur"
+    ],
+    "name:isl_x_preferred":[
+        "\u00c1sgar\u00f0ur"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"955b76313fd59b208c5dab3548c42de7",
+    "wof:hierarchy":[],
+    "wof:id":1444837883,
+    "wof:lastmodified":1566335078,
+    "wof:name":"Asgardur",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.930789443876375,
+    64.14319042498293,
+    -21.930789443876375,
+    64.14319042498293
+],
+  "geometry": {"coordinates":[-21.93078944387637,64.14319042498293],"type":"Point"}
+}

--- a/data/144/483/789/3/1444837893.geojson
+++ b/data/144/483/789/3/1444837893.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
-    "wof:geomhash":"e7169675a9904f4e6f60b518eb45ad94",
-    "wof:hierarchy":[],
+    "wof:geomhash":"bdffd9a40192971e5c25e4432cb66b85",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444837893,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444837893,
-    "wof:lastmodified":1566335078,
+    "wof:lastmodified":1566339062,
     "wof:name":"Tungan",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -21.923021762660927,
+    -21.92302176266093,
     64.1426102104499,
-    -21.923021762660927,
+    -21.92302176266093,
     64.1426102104499
 ],
   "geometry": {"coordinates":[-21.92302176266093,64.1426102104499],"type":"Point"}

--- a/data/144/483/789/3/1444837893.geojson
+++ b/data/144/483/789/3/1444837893.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837893,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.9230217627,64.1426102104,-21.9230217627,64.1426102104",
+    "geom:latitude":64.14261,
+    "geom:longitude":-21.923022,
+    "iso:country":"IS",
+    "lbl:latitude":64.14261,
+    "lbl:longitude":-21.923021,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Tungan"
+    ],
+    "name:isl_x_preferred":[
+        "Tungan"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"e7169675a9904f4e6f60b518eb45ad94",
+    "wof:hierarchy":[],
+    "wof:id":1444837893,
+    "wof:lastmodified":1566335078,
+    "wof:name":"Tungan",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.923021762660927,
+    64.1426102104499,
+    -21.923021762660927,
+    64.1426102104499
+],
+  "geometry": {"coordinates":[-21.92302176266093,64.1426102104499],"type":"Point"}
+}

--- a/data/144/483/790/1/1444837901.geojson
+++ b/data/144/483/790/1/1444837901.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837901,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.8879169934,64.144731366,-21.8879169934,64.144731366",
+    "geom:latitude":64.144731,
+    "geom:longitude":-21.887917,
+    "iso:country":"IS",
+    "lbl:latitude":64.144731,
+    "lbl:longitude":-21.887916,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Teigar"
+    ],
+    "name:isl_x_preferred":[
+        "Teigar"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"90396c43d0f179e1a2afc1e11bdb0761",
+    "wof:hierarchy":[],
+    "wof:id":1444837901,
+    "wof:lastmodified":1566335078,
+    "wof:name":"Teigar",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.887916993410993,
+    64.14473136601441,
+    -21.887916993410993,
+    64.14473136601441
+],
+  "geometry": {"coordinates":[-21.88791699341099,64.14473136601441],"type":"Point"}
+}

--- a/data/144/483/790/1/1444837901.geojson
+++ b/data/144/483/790/1/1444837901.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
-    "wof:geomhash":"90396c43d0f179e1a2afc1e11bdb0761",
-    "wof:hierarchy":[],
+    "wof:geomhash":"e75ea8014b10304e7c8b1ed653df24de",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444837901,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444837901,
-    "wof:lastmodified":1566335078,
+    "wof:lastmodified":1566339065,
     "wof:name":"Teigar",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -21.887916993410993,
+    -21.88791699341099,
     64.14473136601441,
-    -21.887916993410993,
+    -21.88791699341099,
     64.14473136601441
 ],
   "geometry": {"coordinates":[-21.88791699341099,64.14473136601441],"type":"Point"}

--- a/data/144/483/791/1/1444837911.geojson
+++ b/data/144/483/791/1/1444837911.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
-    "wof:geomhash":"314c25417b760fc5d03f334213ed839c",
-    "wof:hierarchy":[],
+    "wof:geomhash":"7741d9a4c2c6204641bfc9c58f6427da",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444837911,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444837911,
-    "wof:lastmodified":1566335078,
+    "wof:lastmodified":1566339066,
     "wof:name":"Laekir",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -21.880020566098047,
+    -21.88002056609805,
     64.14942228753517,
-    -21.880020566098047,
+    -21.88002056609805,
     64.14942228753517
 ],
   "geometry": {"coordinates":[-21.88002056609805,64.14942228753517],"type":"Point"}

--- a/data/144/483/791/1/1444837911.geojson
+++ b/data/144/483/791/1/1444837911.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837911,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.8800205661,64.1494222875,-21.8800205661,64.1494222875",
+    "geom:latitude":64.149422,
+    "geom:longitude":-21.880021,
+    "iso:country":"IS",
+    "lbl:latitude":64.149422,
+    "lbl:longitude":-21.88002,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Laekir"
+    ],
+    "name:isl_x_preferred":[
+        "L\u00e6kir"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"314c25417b760fc5d03f334213ed839c",
+    "wof:hierarchy":[],
+    "wof:id":1444837911,
+    "wof:lastmodified":1566335078,
+    "wof:name":"Laekir",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.880020566098047,
+    64.14942228753517,
+    -21.880020566098047,
+    64.14942228753517
+],
+  "geometry": {"coordinates":[-21.88002056609805,64.14942228753517],"type":"Point"}
+}

--- a/data/144/483/792/1/1444837921.geojson
+++ b/data/144/483/792/1/1444837921.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837921,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.8845982051,64.1531644756,-21.8845982051,64.1531644756",
+    "geom:latitude":64.153164,
+    "geom:longitude":-21.884598,
+    "iso:country":"IS",
+    "lbl:latitude":64.153164,
+    "lbl:longitude":-21.884598,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Laugarnes"
+    ],
+    "name:isl_x_preferred":[
+        "Laugarnes"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"4892ca9f3fb6b7eef7406a83d8f2eef1",
+    "wof:hierarchy":[],
+    "wof:id":1444837921,
+    "wof:lastmodified":1566335078,
+    "wof:name":"Laugarnes",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.884598205120046,
+    64.15316447562712,
+    -21.884598205120046,
+    64.15316447562712
+],
+  "geometry": {"coordinates":[-21.88459820512005,64.15316447562712],"type":"Point"}
+}

--- a/data/144/483/792/1/1444837921.geojson
+++ b/data/144/483/792/1/1444837921.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
-    "wof:geomhash":"4892ca9f3fb6b7eef7406a83d8f2eef1",
-    "wof:hierarchy":[],
+    "wof:geomhash":"9d0077d3bbedea8b51f03f098c725469",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444837921,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444837921,
-    "wof:lastmodified":1566335078,
+    "wof:lastmodified":1566339066,
     "wof:name":"Laugarnes",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -21.884598205120046,
+    -21.88459820512005,
     64.15316447562712,
-    -21.884598205120046,
+    -21.88459820512005,
     64.15316447562712
 ],
   "geometry": {"coordinates":[-21.88459820512005,64.15316447562712],"type":"Point"}

--- a/data/144/483/793/5/1444837935.geojson
+++ b/data/144/483/793/5/1444837935.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837935,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.8567890481,64.1480250746,-21.8567890481,64.1480250746",
+    "geom:latitude":64.148025,
+    "geom:longitude":-21.856789,
+    "iso:country":"IS",
+    "lbl:latitude":64.148025,
+    "lbl:longitude":-21.856789,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Sundahofn"
+    ],
+    "name:isl_x_preferred":[
+        "Sundah\u00f6fn"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"908f5d09803687f66e4e7099c0bd331d",
+    "wof:hierarchy":[],
+    "wof:id":1444837935,
+    "wof:lastmodified":1566335078,
+    "wof:name":"Sundahofn",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.85678904806141,
+    64.1480250746449,
+    -21.85678904806141,
+    64.1480250746449
+],
+  "geometry": {"coordinates":[-21.85678904806141,64.14802507464491],"type":"Point"}
+}

--- a/data/144/483/793/5/1444837935.geojson
+++ b/data/144/483/793/5/1444837935.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
     "wof:geomhash":"908f5d09803687f66e4e7099c0bd331d",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444837935,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444837935,
-    "wof:lastmodified":1566335078,
+    "wof:lastmodified":1566339069,
     "wof:name":"Sundahofn",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],

--- a/data/144/483/794/3/1444837943.geojson
+++ b/data/144/483/794/3/1444837943.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
-    "wof:geomhash":"2a7cb23f2accc52e237b1e0ac01c15ed",
-    "wof:hierarchy":[],
+    "wof:geomhash":"1789a573ebbd71a25660c48cbfcc0cc0",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444837943,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444837943,
-    "wof:lastmodified":1566335078,
+    "wof:lastmodified":1566339070,
     "wof:name":"Laugaras",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -21.866516530983155,
+    -21.86651653098316,
     64.14498090307517,
-    -21.866516530983155,
+    -21.86651653098316,
     64.14498090307517
 ],
   "geometry": {"coordinates":[-21.86651653098316,64.14498090307517],"type":"Point"}

--- a/data/144/483/794/3/1444837943.geojson
+++ b/data/144/483/794/3/1444837943.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837943,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.866516531,64.1449809031,-21.866516531,64.1449809031",
+    "geom:latitude":64.144981,
+    "geom:longitude":-21.866517,
+    "iso:country":"IS",
+    "lbl:latitude":64.144981,
+    "lbl:longitude":-21.866516,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Laugaras"
+    ],
+    "name:isl_x_preferred":[
+        "Laugar\u00e1s"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"2a7cb23f2accc52e237b1e0ac01c15ed",
+    "wof:hierarchy":[],
+    "wof:id":1444837943,
+    "wof:lastmodified":1566335078,
+    "wof:name":"Laugaras",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.866516530983155,
+    64.14498090307517,
+    -21.866516530983155,
+    64.14498090307517
+],
+  "geometry": {"coordinates":[-21.86651653098316,64.14498090307517],"type":"Point"}
+}

--- a/data/144/483/795/3/1444837953.geojson
+++ b/data/144/483/795/3/1444837953.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837953,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.8551868744,64.1400396519,-21.8551868744,64.1400396519",
+    "geom:latitude":64.14004,
+    "geom:longitude":-21.855187,
+    "iso:country":"IS",
+    "lbl:latitude":64.14004,
+    "lbl:longitude":-21.855186,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Sund"
+    ],
+    "name:isl_x_preferred":[
+        "Sund"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"5e8106485b9d68a1b61b171b31f87057",
+    "wof:hierarchy":[],
+    "wof:id":1444837953,
+    "wof:lastmodified":1566335078,
+    "wof:name":"Sund",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.855186874403717,
+    64.14003965185516,
+    -21.855186874403717,
+    64.14003965185516
+],
+  "geometry": {"coordinates":[-21.85518687440372,64.14003965185516],"type":"Point"}
+}

--- a/data/144/483/795/3/1444837953.geojson
+++ b/data/144/483/795/3/1444837953.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
-    "wof:geomhash":"5e8106485b9d68a1b61b171b31f87057",
-    "wof:hierarchy":[],
+    "wof:geomhash":"7d611f768e75cb384c8f67eb6d83a9e4",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444837953,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444837953,
-    "wof:lastmodified":1566335078,
+    "wof:lastmodified":1566339073,
     "wof:name":"Sund",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -21.855186874403717,
+    -21.85518687440372,
     64.14003965185516,
-    -21.855186874403717,
+    -21.85518687440372,
     64.14003965185516
 ],
   "geometry": {"coordinates":[-21.85518687440372,64.14003965185516],"type":"Point"}

--- a/data/144/483/796/5/1444837965.geojson
+++ b/data/144/483/796/5/1444837965.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837965,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.8621677739,64.1348978208,-21.8621677739,64.1348978208",
+    "geom:latitude":64.134898,
+    "geom:longitude":-21.862168,
+    "iso:country":"IS",
+    "lbl:latitude":64.134898,
+    "lbl:longitude":-21.862167,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Heimar"
+    ],
+    "name:isl_x_preferred":[
+        "Heimar"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"4c1cfe7ff0a25d16790fda99be6f3497",
+    "wof:hierarchy":[],
+    "wof:id":1444837965,
+    "wof:lastmodified":1566335078,
+    "wof:name":"Heimar",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.862167773912258,
+    64.13489782079169,
+    -21.862167773912258,
+    64.13489782079169
+],
+  "geometry": {"coordinates":[-21.86216777391226,64.13489782079169],"type":"Point"}
+}

--- a/data/144/483/796/5/1444837965.geojson
+++ b/data/144/483/796/5/1444837965.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
-    "wof:geomhash":"4c1cfe7ff0a25d16790fda99be6f3497",
-    "wof:hierarchy":[],
+    "wof:geomhash":"df00a43a9245f66df54a9db26c973496",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444837965,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444837965,
-    "wof:lastmodified":1566335078,
+    "wof:lastmodified":1566339074,
     "wof:name":"Heimar",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -21.862167773912258,
+    -21.86216777391226,
     64.13489782079169,
-    -21.862167773912258,
+    -21.86216777391226,
     64.13489782079169
 ],
   "geometry": {"coordinates":[-21.86216777391226,64.13489782079169],"type":"Point"}

--- a/data/144/483/797/5/1444837975.geojson
+++ b/data/144/483/797/5/1444837975.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
-    "wof:geomhash":"8a2d2d5565f955d649c351fd0025fe1b",
-    "wof:hierarchy":[],
+    "wof:geomhash":"e742869d17e0cecd42dacdbbd5ecfa24",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444837975,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444837975,
-    "wof:lastmodified":1566335078,
+    "wof:lastmodified":1566339077,
     "wof:name":"Vogar",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -21.850952558308364,
+    -21.85095255830836,
     64.13075371090835,
-    -21.850952558308364,
+    -21.85095255830836,
     64.13075371090835
 ],
   "geometry": {"coordinates":[-21.85095255830836,64.13075371090835],"type":"Point"}

--- a/data/144/483/797/5/1444837975.geojson
+++ b/data/144/483/797/5/1444837975.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837975,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.8509525583,64.1307537109,-21.8509525583,64.1307537109",
+    "geom:latitude":64.130754,
+    "geom:longitude":-21.850953,
+    "iso:country":"IS",
+    "lbl:latitude":64.130754,
+    "lbl:longitude":-21.850952,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Vogar"
+    ],
+    "name:isl_x_preferred":[
+        "Vogar"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"8a2d2d5565f955d649c351fd0025fe1b",
+    "wof:hierarchy":[],
+    "wof:id":1444837975,
+    "wof:lastmodified":1566335078,
+    "wof:name":"Vogar",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.850952558308364,
+    64.13075371090835,
+    -21.850952558308364,
+    64.13075371090835
+],
+  "geometry": {"coordinates":[-21.85095255830836,64.13075371090835],"type":"Point"}
+}

--- a/data/144/483/798/7/1444837987.geojson
+++ b/data/144/483/798/7/1444837987.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837987,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.8694919963,64.130504046,-21.8694919963,64.130504046",
+    "geom:latitude":64.130504,
+    "geom:longitude":-21.869492,
+    "iso:country":"IS",
+    "lbl:latitude":64.130504,
+    "lbl:longitude":-21.869491,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Skeifan"
+    ],
+    "name:isl_x_preferred":[
+        "Skeifan"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"30a1f45c105853c937830bbca02aa941",
+    "wof:hierarchy":[],
+    "wof:id":1444837987,
+    "wof:lastmodified":1566335078,
+    "wof:name":"Skeifan",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.869491996347453,
+    64.13050404599252,
+    -21.869491996347453,
+    64.13050404599252
+],
+  "geometry": {"coordinates":[-21.86949199634745,64.13050404599252],"type":"Point"}
+}

--- a/data/144/483/798/7/1444837987.geojson
+++ b/data/144/483/798/7/1444837987.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
-    "wof:geomhash":"30a1f45c105853c937830bbca02aa941",
-    "wof:hierarchy":[],
+    "wof:geomhash":"7d1079cb225338c5d30ba030659d3997",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444837987,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444837987,
-    "wof:lastmodified":1566335078,
+    "wof:lastmodified":1566339077,
     "wof:name":"Skeifan",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -21.869491996347453,
+    -21.86949199634745,
     64.13050404599252,
-    -21.869491996347453,
+    -21.86949199634745,
     64.13050404599252
 ],
   "geometry": {"coordinates":[-21.86949199634745,64.13050404599252],"type":"Point"}

--- a/data/144/483/799/9/1444837999.geojson
+++ b/data/144/483/799/9/1444837999.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444837999,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.8577045759,64.1274579534,-21.8577045759,64.1274579534",
+    "geom:latitude":64.127458,
+    "geom:longitude":-21.857705,
+    "iso:country":"IS",
+    "lbl:latitude":64.127458,
+    "lbl:longitude":-21.857704,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Merkur"
+    ],
+    "name:isl_x_preferred":[
+        "Merkur"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"921e83c68b8628a3682c81d2156f333c",
+    "wof:hierarchy":[],
+    "wof:id":1444837999,
+    "wof:lastmodified":1566335078,
+    "wof:name":"Merkur",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.85770457586581,
+    64.12745795336681,
+    -21.85770457586581,
+    64.12745795336681
+],
+  "geometry": {"coordinates":[-21.85770457586581,64.12745795336681],"type":"Point"}
+}

--- a/data/144/483/799/9/1444837999.geojson
+++ b/data/144/483/799/9/1444837999.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
     "wof:geomhash":"921e83c68b8628a3682c81d2156f333c",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444837999,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444837999,
-    "wof:lastmodified":1566335078,
+    "wof:lastmodified":1566339078,
     "wof:name":"Merkur",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],

--- a/data/144/483/801/1/1444838011.geojson
+++ b/data/144/483/801/1/1444838011.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838011,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.885055969,64.1345483414,-21.885055969,64.1345483414",
+    "geom:latitude":64.134548,
+    "geom:longitude":-21.885056,
+    "iso:country":"IS",
+    "lbl:latitude":64.134548,
+    "lbl:longitude":-21.885055,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Haaleiti"
+    ],
+    "name:isl_x_preferred":[
+        "H\u00e1aleiti"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"f71ae1d739cb464674c2fdbcd1272f9e",
+    "wof:hierarchy":[],
+    "wof:id":1444838011,
+    "wof:lastmodified":1566335078,
+    "wof:name":"Haaleiti",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.885055969022247,
+    64.13454834141766,
+    -21.885055969022247,
+    64.13454834141766
+],
+  "geometry": {"coordinates":[-21.88505596902225,64.13454834141766],"type":"Point"}
+}

--- a/data/144/483/801/1/1444838011.geojson
+++ b/data/144/483/801/1/1444838011.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
-    "wof:geomhash":"f71ae1d739cb464674c2fdbcd1272f9e",
-    "wof:hierarchy":[],
+    "wof:geomhash":"3ab95ceaa78acae1a1d2393613327e67",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444838011,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444838011,
-    "wof:lastmodified":1566335078,
+    "wof:lastmodified":1566339079,
     "wof:name":"Haaleiti",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -21.885055969022247,
+    -21.88505596902225,
     64.13454834141766,
-    -21.885055969022247,
+    -21.88505596902225,
     64.13454834141766
 ],
   "geometry": {"coordinates":[-21.88505596902225,64.13454834141766],"type":"Point"}

--- a/data/144/483/802/3/1444838023.geojson
+++ b/data/144/483/802/3/1444838023.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
     "wof:geomhash":"8ee74289ecaf7776d2f9f2effa688e0f",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444838023,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444838023,
-    "wof:lastmodified":1566335078,
+    "wof:lastmodified":1566339082,
     "wof:name":"Gerdi",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],

--- a/data/144/483/802/3/1444838023.geojson
+++ b/data/144/483/802/3/1444838023.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838023,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.8682331456,64.1249609071,-21.8682331456,64.1249609071",
+    "geom:latitude":64.124961,
+    "geom:longitude":-21.868233,
+    "iso:country":"IS",
+    "lbl:latitude":64.124961,
+    "lbl:longitude":-21.868233,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Gerdi"
+    ],
+    "name:isl_x_preferred":[
+        "Ger\u00f0i"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"8ee74289ecaf7776d2f9f2effa688e0f",
+    "wof:hierarchy":[],
+    "wof:id":1444838023,
+    "wof:lastmodified":1566335078,
+    "wof:name":"Gerdi",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.8682331456164,
+    64.12496090708244,
+    -21.8682331456164,
+    64.12496090708244
+],
+  "geometry": {"coordinates":[-21.8682331456164,64.12496090708244],"type":"Point"}
+}

--- a/data/144/483/803/5/1444838035.geojson
+++ b/data/144/483/803/5/1444838035.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
     "wof:geomhash":"8dbf2e79c6582c9a67b2142c38b9fc2b",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444838035,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444838035,
-    "wof:lastmodified":1566335078,
+    "wof:lastmodified":1566339082,
     "wof:name":"Kringla",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],

--- a/data/144/483/803/5/1444838035.geojson
+++ b/data/144/483/803/5/1444838035.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838035,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.8954700978,64.1282569608,-21.8954700978,64.1282569608",
+    "geom:latitude":64.128257,
+    "geom:longitude":-21.89547,
+    "iso:country":"IS",
+    "lbl:latitude":64.128257,
+    "lbl:longitude":-21.89547,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Kringla"
+    ],
+    "name:isl_x_preferred":[
+        "Kringla"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"8dbf2e79c6582c9a67b2142c38b9fc2b",
+    "wof:hierarchy":[],
+    "wof:id":1444838035,
+    "wof:lastmodified":1566335078,
+    "wof:name":"Kringla",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.89547009779729,
+    64.12825696079,
+    -21.89547009779729,
+    64.12825696079
+],
+  "geometry": {"coordinates":[-21.89547009779729,64.12825696079],"type":"Point"}
+}

--- a/data/144/483/804/5/1444838045.geojson
+++ b/data/144/483/804/5/1444838045.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838045,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.8780750695,64.1200660455,-21.8780750695,64.1200660455",
+    "geom:latitude":64.120066,
+    "geom:longitude":-21.878075,
+    "iso:country":"IS",
+    "lbl:latitude":64.120066,
+    "lbl:longitude":-21.878075,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Fossvogur"
+    ],
+    "name:isl_x_preferred":[
+        "Fossvogur"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"8ef68d77cef8366b27dff55a5f47d96b",
+    "wof:hierarchy":[],
+    "wof:id":1444838045,
+    "wof:lastmodified":1566335079,
+    "wof:name":"Fossvogur",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.8780750695137,
+    64.12006604545164,
+    -21.8780750695137,
+    64.12006604545164
+],
+  "geometry": {"coordinates":[-21.8780750695137,64.12006604545164],"type":"Point"}
+}

--- a/data/144/483/804/5/1444838045.geojson
+++ b/data/144/483/804/5/1444838045.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
     "wof:geomhash":"8ef68d77cef8366b27dff55a5f47d96b",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444838045,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444838045,
-    "wof:lastmodified":1566335079,
+    "wof:lastmodified":1566339083,
     "wof:name":"Fossvogur",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],

--- a/data/144/483/805/7/1444838057.geojson
+++ b/data/144/483/805/7/1444838057.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
-    "wof:geomhash":"5c763fe704307ffe52ab5eebd8dd4ae5",
-    "wof:hierarchy":[],
+    "wof:geomhash":"c421e68ff77c70ea1c77be9ad1318b6e",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444838057,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444838057,
-    "wof:lastmodified":1566335079,
+    "wof:lastmodified":1566339084,
     "wof:name":"Mular",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -21.876183641787968,
+    -21.87618364178797,
     64.13594850015679,
-    -21.876183641787968,
+    -21.87618364178797,
     64.13594850015679
 ],
   "geometry": {"coordinates":[-21.87618364178797,64.13594850015679],"type":"Point"}

--- a/data/144/483/805/7/1444838057.geojson
+++ b/data/144/483/805/7/1444838057.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838057,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.8761836418,64.1359485002,-21.8761836418,64.1359485002",
+    "geom:latitude":64.135949,
+    "geom:longitude":-21.876184,
+    "iso:country":"IS",
+    "lbl:latitude":64.135948,
+    "lbl:longitude":-21.876183,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Mular"
+    ],
+    "name:isl_x_preferred":[
+        "M\u00falar"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"5c763fe704307ffe52ab5eebd8dd4ae5",
+    "wof:hierarchy":[],
+    "wof:id":1444838057,
+    "wof:lastmodified":1566335079,
+    "wof:name":"Mular",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.876183641787968,
+    64.13594850015679,
+    -21.876183641787968,
+    64.13594850015679
+],
+  "geometry": {"coordinates":[-21.87618364178797,64.13594850015679],"type":"Point"}
+}

--- a/data/144/483/806/9/1444838069.geojson
+++ b/data/144/483/806/9/1444838069.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838069,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.8465434291,64.1066779645,-21.8465434291,64.1066779645",
+    "geom:latitude":64.106678,
+    "geom:longitude":-21.846543,
+    "iso:country":"IS",
+    "lbl:latitude":64.106678,
+    "lbl:longitude":-21.846543,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":15.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Mjodd"
+    ],
+    "name:isl_x_preferred":[
+        "Mj\u00f3dd"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"5d9c20b04e5689515b34456c2ea3b540",
+    "wof:hierarchy":[],
+    "wof:id":1444838069,
+    "wof:lastmodified":1566335079,
+    "wof:name":"Mjodd",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.84654342912054,
+    64.10667796447902,
+    -21.84654342912054,
+    64.10667796447902
+],
+  "geometry": {"coordinates":[-21.84654342912054,64.10667796447902],"type":"Point"}
+}

--- a/data/144/483/806/9/1444838069.geojson
+++ b/data/144/483/806/9/1444838069.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
     "wof:geomhash":"5d9c20b04e5689515b34456c2ea3b540",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444838069,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444838069,
-    "wof:lastmodified":1566335079,
+    "wof:lastmodified":1566339087,
     "wof:name":"Mjodd",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],

--- a/data/144/483/807/9/1444838079.geojson
+++ b/data/144/483/807/9/1444838079.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838079,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.8432246408,64.109726338,-21.8432246408,64.109726338",
+    "geom:latitude":64.109726,
+    "geom:longitude":-21.843225,
+    "iso:country":"IS",
+    "lbl:latitude":64.109726,
+    "lbl:longitude":-21.843224,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Mjodd-nordur"
+    ],
+    "name:isl_x_preferred":[
+        "Mj\u00f3dd-nor\u00f0ur"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"cbc32f080e7c21a594d4227399a447f2",
+    "wof:hierarchy":[],
+    "wof:id":1444838079,
+    "wof:lastmodified":1566335079,
+    "wof:name":"Mjodd-nordur",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.84322464082959,
+    64.1097263380062,
+    -21.84322464082959,
+    64.1097263380062
+],
+  "geometry": {"coordinates":[-21.84322464082959,64.1097263380062],"type":"Point"}
+}

--- a/data/144/483/807/9/1444838079.geojson
+++ b/data/144/483/807/9/1444838079.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
     "wof:geomhash":"cbc32f080e7c21a594d4227399a447f2",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444838079,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444838079,
-    "wof:lastmodified":1566335079,
+    "wof:lastmodified":1566339087,
     "wof:name":"Mjodd-nordur",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],

--- a/data/144/483/809/1/1444838091.geojson
+++ b/data/144/483/809/1/1444838091.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
-    "wof:geomhash":"3319de5489a304a2417c8aead6d2e368",
-    "wof:hierarchy":[],
+    "wof:geomhash":"41277e2eb6cdcb87106dc8ff33ce16dc",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444838091,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444838091,
-    "wof:lastmodified":1566335079,
+    "wof:lastmodified":1566339088,
     "wof:name":"Mjodd-sudur",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -21.850548863264784,
+    -21.85054886326478,
     64.10497868825338,
-    -21.850548863264784,
+    -21.85054886326478,
     64.10497868825338
 ],
   "geometry": {"coordinates":[-21.85054886326478,64.10497868825338],"type":"Point"}

--- a/data/144/483/809/1/1444838091.geojson
+++ b/data/144/483/809/1/1444838091.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838091,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.8505488633,64.1049786883,-21.8505488633,64.1049786883",
+    "geom:latitude":64.104979,
+    "geom:longitude":-21.850549,
+    "iso:country":"IS",
+    "lbl:latitude":64.104979,
+    "lbl:longitude":-21.850548,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Mjodd-sudur"
+    ],
+    "name:isl_x_preferred":[
+        "Mj\u00f3dd-su\u00f0ur"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"3319de5489a304a2417c8aead6d2e368",
+    "wof:hierarchy":[],
+    "wof:id":1444838091,
+    "wof:lastmodified":1566335079,
+    "wof:name":"Mjodd-sudur",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.850548863264784,
+    64.10497868825338,
+    -21.850548863264784,
+    64.10497868825338
+],
+  "geometry": {"coordinates":[-21.85054886326478,64.10497868825338],"type":"Point"}
+}

--- a/data/144/483/810/5/1444838105.geojson
+++ b/data/144/483/810/5/1444838105.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838105,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.8409358213,64.0979307851,-21.8409358213,64.0979307851",
+    "geom:latitude":64.097931,
+    "geom:longitude":-21.840936,
+    "iso:country":"IS",
+    "lbl:latitude":64.097931,
+    "lbl:longitude":-21.840935,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Sel"
+    ],
+    "name:isl_x_preferred":[
+        "Sel"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"902e267c823df2e3d174f2cc498c58e7",
+    "wof:hierarchy":[],
+    "wof:id":1444838105,
+    "wof:lastmodified":1566335079,
+    "wof:name":"Sel",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.840935821318585,
+    64.09793078514767,
+    -21.840935821318585,
+    64.09793078514767
+],
+  "geometry": {"coordinates":[-21.84093582131858,64.09793078514767],"type":"Point"}
+}

--- a/data/144/483/810/5/1444838105.geojson
+++ b/data/144/483/810/5/1444838105.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
-    "wof:geomhash":"902e267c823df2e3d174f2cc498c58e7",
-    "wof:hierarchy":[],
+    "wof:geomhash":"080b5ab426948b4ff146ca5b48935b42",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444838105,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444838105,
-    "wof:lastmodified":1566335079,
+    "wof:lastmodified":1566339091,
     "wof:name":"Sel",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -21.840935821318585,
+    -21.84093582131858,
     64.09793078514767,
-    -21.840935821318585,
+    -21.84093582131858,
     64.09793078514767
 ],
   "geometry": {"coordinates":[-21.84093582131858,64.09793078514767],"type":"Point"}

--- a/data/144/483/811/5/1444838115.geojson
+++ b/data/144/483/811/5/1444838115.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838115,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.8221675013,64.1004302599,-21.8221675013,64.1004302599",
+    "geom:latitude":64.10043,
+    "geom:longitude":-21.822168,
+    "iso:country":"IS",
+    "lbl:latitude":64.10043,
+    "lbl:longitude":-21.822167,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Fell"
+    ],
+    "name:isl_x_preferred":[
+        "Fell"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"ca46176ff01adb151bf39f74636ffc2a",
+    "wof:hierarchy":[],
+    "wof:id":1444838115,
+    "wof:lastmodified":1566335079,
+    "wof:name":"Fell",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.822167501328398,
+    64.10043025990453,
+    -21.822167501328398,
+    64.10043025990453
+],
+  "geometry": {"coordinates":[-21.8221675013284,64.10043025990453],"type":"Point"}
+}

--- a/data/144/483/811/5/1444838115.geojson
+++ b/data/144/483/811/5/1444838115.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
-    "wof:geomhash":"ca46176ff01adb151bf39f74636ffc2a",
-    "wof:hierarchy":[],
+    "wof:geomhash":"82e87f6e4efe198e2de0363227f10af4",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444838115,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444838115,
-    "wof:lastmodified":1566335079,
+    "wof:lastmodified":1566339091,
     "wof:name":"Fell",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -21.822167501328398,
+    -21.8221675013284,
     64.10043025990453,
-    -21.822167501328398,
+    -21.8221675013284,
     64.10043025990453
 ],
   "geometry": {"coordinates":[-21.8221675013284,64.10043025990453],"type":"Point"}

--- a/data/144/483/812/7/1444838127.geojson
+++ b/data/144/483/812/7/1444838127.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838127,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.833153835,64.10737762,-21.833153835,64.10737762",
+    "geom:latitude":64.107378,
+    "geom:longitude":-21.833154,
+    "iso:country":"IS",
+    "lbl:latitude":64.107378,
+    "lbl:longitude":-21.833153,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Bakkar"
+    ],
+    "name:isl_x_preferred":[
+        "Bakkar"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"140759f46e11cc2dc96f9bf6c954f863",
+    "wof:hierarchy":[],
+    "wof:id":1444838127,
+    "wof:lastmodified":1566335079,
+    "wof:name":"Bakkar",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.833153834981193,
+    64.10737762001193,
+    -21.833153834981193,
+    64.10737762001193
+],
+  "geometry": {"coordinates":[-21.83315383498119,64.10737762001193],"type":"Point"}
+}

--- a/data/144/483/812/7/1444838127.geojson
+++ b/data/144/483/812/7/1444838127.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
-    "wof:geomhash":"140759f46e11cc2dc96f9bf6c954f863",
-    "wof:hierarchy":[],
+    "wof:geomhash":"a878625789d9b654989d9a6fb4209f8f",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444838127,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444838127,
-    "wof:lastmodified":1566335079,
+    "wof:lastmodified":1566339092,
     "wof:name":"Bakkar",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -21.833153834981193,
+    -21.83315383498119,
     64.10737762001193,
-    -21.833153834981193,
+    -21.83315383498119,
     64.10737762001193
 ],
   "geometry": {"coordinates":[-21.83315383498119,64.10737762001193],"type":"Point"}

--- a/data/144/483/813/7/1444838137.geojson
+++ b/data/144/483/813/7/1444838137.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838137,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.8139277511,64.1099761865,-21.8139277511,64.1099761865",
+    "geom:latitude":64.109976,
+    "geom:longitude":-21.813928,
+    "iso:country":"IS",
+    "lbl:latitude":64.109976,
+    "lbl:longitude":-21.813927,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Holar"
+    ],
+    "name:isl_x_preferred":[
+        "H\u00f3lar"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"d39d79608ada579b11be1558150d5432",
+    "wof:hierarchy":[],
+    "wof:id":1444838137,
+    "wof:lastmodified":1566335079,
+    "wof:name":"Holar",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.813927751088798,
+    64.10997618647235,
+    -21.813927751088798,
+    64.10997618647235
+],
+  "geometry": {"coordinates":[-21.8139277510888,64.10997618647235],"type":"Point"}
+}

--- a/data/144/483/813/7/1444838137.geojson
+++ b/data/144/483/813/7/1444838137.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
-    "wof:geomhash":"d39d79608ada579b11be1558150d5432",
-    "wof:hierarchy":[],
+    "wof:geomhash":"9445b5cbfe76519387c26f7969a9c194",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444838137,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444838137,
-    "wof:lastmodified":1566335079,
+    "wof:lastmodified":1566339093,
     "wof:name":"Holar",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -21.813927751088798,
+    -21.8139277510888,
     64.10997618647235,
-    -21.813927751088798,
+    -21.8139277510888,
     64.10997618647235
 ],
   "geometry": {"coordinates":[-21.8139277510888,64.10997618647235],"type":"Point"}

--- a/data/144/483/814/9/1444838149.geojson
+++ b/data/144/483/814/9/1444838149.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838149,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.8178187443,64.1051786434,-21.8178187443,64.1051786434",
+    "geom:latitude":64.105179,
+    "geom:longitude":-21.817819,
+    "iso:country":"IS",
+    "lbl:latitude":64.105179,
+    "lbl:longitude":-21.817818,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Berg"
+    ],
+    "name:isl_x_preferred":[
+        "Berg"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"747cfaf2d3a2d2effd1f468468b6c844",
+    "wof:hierarchy":[],
+    "wof:id":1444838149,
+    "wof:lastmodified":1566335079,
+    "wof:name":"Berg",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.817818744257494,
+    64.1051786433546,
+    -21.817818744257494,
+    64.1051786433546
+],
+  "geometry": {"coordinates":[-21.81781874425749,64.10517864335461],"type":"Point"}
+}

--- a/data/144/483/814/9/1444838149.geojson
+++ b/data/144/483/814/9/1444838149.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
-    "wof:geomhash":"747cfaf2d3a2d2effd1f468468b6c844",
-    "wof:hierarchy":[],
+    "wof:geomhash":"d740e46e55fae3ac912a4ce9fee2c773",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444838149,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444838149,
-    "wof:lastmodified":1566335079,
+    "wof:lastmodified":1566339096,
     "wof:name":"Berg",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -21.817818744257494,
+    -21.81781874425749,
     64.1051786433546,
-    -21.817818744257494,
+    -21.81781874425749,
     64.1051786433546
 ],
   "geometry": {"coordinates":[-21.81781874425749,64.10517864335461],"type":"Point"}

--- a/data/144/483/816/1/1444838161.geojson
+++ b/data/144/483/816/1/1444838161.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838161,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.8321238662,64.1118250186,-21.8321238662,64.1118250186",
+    "geom:latitude":64.111825,
+    "geom:longitude":-21.832124,
+    "iso:country":"IS",
+    "lbl:latitude":64.111825,
+    "lbl:longitude":-21.832123,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Stekkir"
+    ],
+    "name:isl_x_preferred":[
+        "Stekkir"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"bc30ad7d5cd229321b613fadbbebc7fd",
+    "wof:hierarchy":[],
+    "wof:id":1444838161,
+    "wof:lastmodified":1566335079,
+    "wof:name":"Stekkir",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.832123866201243,
+    64.1118250186112,
+    -21.832123866201243,
+    64.1118250186112
+],
+  "geometry": {"coordinates":[-21.83212386620124,64.1118250186112],"type":"Point"}
+}

--- a/data/144/483/816/1/1444838161.geojson
+++ b/data/144/483/816/1/1444838161.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
-    "wof:geomhash":"bc30ad7d5cd229321b613fadbbebc7fd",
-    "wof:hierarchy":[],
+    "wof:geomhash":"176157b4a5bf4dd05b66dfd656fbe532",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444838161,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444838161,
-    "wof:lastmodified":1566335079,
+    "wof:lastmodified":1566339096,
     "wof:name":"Stekkir",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -21.832123866201243,
+    -21.83212386620124,
     64.1118250186112,
-    -21.832123866201243,
+    -21.83212386620124,
     64.1118250186112
 ],
   "geometry": {"coordinates":[-21.83212386620124,64.1118250186112],"type":"Point"}

--- a/data/144/483/817/1/1444838171.geojson
+++ b/data/144/483/817/1/1444838171.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838171,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.823540793,64.1222161657,-21.823540793,64.1222161657",
+    "geom:latitude":64.122216,
+    "geom:longitude":-21.823541,
+    "iso:country":"IS",
+    "lbl:latitude":64.122216,
+    "lbl:longitude":-21.82354,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Artunsholt"
+    ],
+    "name:isl_x_preferred":[
+        "\u00c1rt\u00fansholt"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"ed7fe9019dae90c7aee5dfb9bb167da3",
+    "wof:hierarchy":[],
+    "wof:id":1444838171,
+    "wof:lastmodified":1566335079,
+    "wof:name":"Artunsholt",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.82354079303499,
+    64.12221616574752,
+    -21.82354079303499,
+    64.12221616574752
+],
+  "geometry": {"coordinates":[-21.82354079303499,64.12221616574752],"type":"Point"}
+}

--- a/data/144/483/817/1/1444838171.geojson
+++ b/data/144/483/817/1/1444838171.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
     "wof:geomhash":"ed7fe9019dae90c7aee5dfb9bb167da3",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444838171,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444838171,
-    "wof:lastmodified":1566335079,
+    "wof:lastmodified":1566339097,
     "wof:name":"Artunsholt",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],

--- a/data/144/483/818/1/1444838181.geojson
+++ b/data/144/483/818/1/1444838181.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
     "wof:geomhash":"483a15106e0f1fec261a386645c80781",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444838181,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444838181,
-    "wof:lastmodified":1566335079,
+    "wof:lastmodified":1566339098,
     "wof:name":"Halsar",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],

--- a/data/144/483/818/1/1444838181.geojson
+++ b/data/144/483/818/1/1444838181.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838181,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.7932139345,64.1217166802,-21.7932139345,64.1217166802",
+    "geom:latitude":64.121717,
+    "geom:longitude":-21.793214,
+    "iso:country":"IS",
+    "lbl:latitude":64.121717,
+    "lbl:longitude":-21.793213,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Halsar"
+    ],
+    "name:isl_x_preferred":[
+        "H\u00e1lsar"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"483a15106e0f1fec261a386645c80781",
+    "wof:hierarchy":[],
+    "wof:id":1444838181,
+    "wof:lastmodified":1566335079,
+    "wof:name":"Halsar",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.79321393451425,
+    64.12171668023844,
+    -21.79321393451425,
+    64.12171668023844
+],
+  "geometry": {"coordinates":[-21.79321393451425,64.12171668023844],"type":"Point"}
+}

--- a/data/144/483/819/5/1444838195.geojson
+++ b/data/144/483/819/5/1444838195.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
     "wof:geomhash":"0220310504e7c606b519158dae36f75d",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444838195,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444838195,
-    "wof:lastmodified":1566335079,
+    "wof:lastmodified":1566339101,
     "wof:name":"Selas",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],

--- a/data/144/483/819/5/1444838195.geojson
+++ b/data/144/483/819/5/1444838195.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838195,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.786461917,64.1092266249,-21.786461917,64.1092266249",
+    "geom:latitude":64.109227,
+    "geom:longitude":-21.786462,
+    "iso:country":"IS",
+    "lbl:latitude":64.109227,
+    "lbl:longitude":-21.786461,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Selas"
+    ],
+    "name:isl_x_preferred":[
+        "Sel\u00e1s"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"0220310504e7c606b519158dae36f75d",
+    "wof:hierarchy":[],
+    "wof:id":1444838195,
+    "wof:lastmodified":1566335079,
+    "wof:name":"Selas",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.7864619169568,
+    64.10922662491127,
+    -21.7864619169568,
+    64.10922662491127
+],
+  "geometry": {"coordinates":[-21.7864619169568,64.10922662491127],"type":"Point"}
+}

--- a/data/144/483/825/5/1444838255.geojson
+++ b/data/144/483/825/5/1444838255.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838255,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.7906962331,64.1021297745,-21.7906962331,64.1021297745",
+    "geom:latitude":64.10213,
+    "geom:longitude":-21.790696,
+    "iso:country":"IS",
+    "lbl:latitude":64.10213,
+    "lbl:longitude":-21.790696,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "V\u00eddidalur"
+    ],
+    "name:isl_x_preferred":[
+        "V\u00ed\u00f0idalur"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"386a38d506f06d267170163dfaecfc7c",
+    "wof:hierarchy":[],
+    "wof:id":1444838255,
+    "wof:lastmodified":1566335079,
+    "wof:name":"V\u00eddidalur",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.79069623305215,
+    64.10212977448246,
+    -21.79069623305215,
+    64.10212977448246
+],
+  "geometry": {"coordinates":[-21.79069623305215,64.10212977448246],"type":"Point"}
+}

--- a/data/144/483/825/5/1444838255.geojson
+++ b/data/144/483/825/5/1444838255.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
     "wof:geomhash":"386a38d506f06d267170163dfaecfc7c",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444838255,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444838255,
-    "wof:lastmodified":1566335079,
+    "wof:lastmodified":1566339101,
     "wof:name":"V\u00eddidalur",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],

--- a/data/144/483/826/7/1444838267.geojson
+++ b/data/144/483/826/7/1444838267.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
     "wof:geomhash":"4f6d2319cfe88a2e3a522d31c3f2aef5",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444838267,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444838267,
-    "wof:lastmodified":1566335079,
+    "wof:lastmodified":1566339102,
     "wof:name":"Nordlingaholt",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],

--- a/data/144/483/826/7/1444838267.geojson
+++ b/data/144/483/826/7/1444838267.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838267,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.7736445277,64.1009801142,-21.7736445277,64.1009801142",
+    "geom:latitude":64.10098,
+    "geom:longitude":-21.773645,
+    "iso:country":"IS",
+    "lbl:latitude":64.10098,
+    "lbl:longitude":-21.773644,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Nordlingaholt"
+    ],
+    "name:isl_x_preferred":[
+        "Nor\u00f0lingaholt"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"4f6d2319cfe88a2e3a522d31c3f2aef5",
+    "wof:hierarchy":[],
+    "wof:id":1444838267,
+    "wof:lastmodified":1566335079,
+    "wof:name":"Nordlingaholt",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.7736445276952,
+    64.10098011421758,
+    -21.7736445276952,
+    64.10098011421758
+],
+  "geometry": {"coordinates":[-21.7736445276952,64.10098011421758],"type":"Point"}
+}

--- a/data/144/483/827/7/1444838277.geojson
+++ b/data/144/483/827/7/1444838277.geojson
@@ -26,13 +26,25 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
-    "wof:geomhash":"c086e143d045cf569bde89ef18201b47",
-    "wof:hierarchy":[],
+    "wof:geomhash":"a3e9484b4d48c5f1d72f594a8131eabe",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":-1,
+            "neighbourhood_id":1444838277,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444838277,
-    "wof:lastmodified":1566335079,
+    "wof:lastmodified":1566339103,
     "wof:name":"Almannadalur",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
@@ -42,9 +54,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -21.736680092592565,
+    -21.73668009259256,
     64.09993038291665,
-    -21.736680092592565,
+    -21.73668009259256,
     64.09993038291665
 ],
   "geometry": {"coordinates":[-21.73668009259256,64.09993038291665],"type":"Point"}

--- a/data/144/483/827/7/1444838277.geojson
+++ b/data/144/483/827/7/1444838277.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444838277,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.7366800926,64.0999303829,-21.7366800926,64.0999303829",
+    "geom:latitude":64.09993,
+    "geom:longitude":-21.73668,
+    "iso:country":"IS",
+    "lbl:latitude":64.09993,
+    "lbl:longitude":-21.73668,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Almannadalur"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"c086e143d045cf569bde89ef18201b47",
+    "wof:hierarchy":[],
+    "wof:id":1444838277,
+    "wof:lastmodified":1566335079,
+    "wof:name":"Almannadalur",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.736680092592565,
+    64.09993038291665,
+    -21.736680092592565,
+    64.09993038291665
+],
+  "geometry": {"coordinates":[-21.73668009259256,64.09993038291665],"type":"Point"}
+}

--- a/data/144/483/828/9/1444838289.geojson
+++ b/data/144/483/828/9/1444838289.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838289,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.7583384872,64.1261908913,-21.7583384872,64.1261908913",
+    "geom:latitude":64.126191,
+    "geom:longitude":-21.758338,
+    "iso:country":"IS",
+    "lbl:latitude":64.126191,
+    "lbl:longitude":-21.758338,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Grafarholt"
+    ],
+    "name:isl_x_preferred":[
+        "Grafarholt"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"7464d1452682649f6ba17ad2281d1359",
+    "wof:hierarchy":[],
+    "wof:id":1444838289,
+    "wof:lastmodified":1566335079,
+    "wof:name":"Grafarholt",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.758338487215546,
+    64.12619089132431,
+    -21.758338487215546,
+    64.12619089132431
+],
+  "geometry": {"coordinates":[-21.75833848721555,64.12619089132431],"type":"Point"}
+}

--- a/data/144/483/828/9/1444838289.geojson
+++ b/data/144/483/828/9/1444838289.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
-    "wof:geomhash":"7464d1452682649f6ba17ad2281d1359",
-    "wof:hierarchy":[],
+    "wof:geomhash":"6ee015bf22773b301361d1aa852b3a5b",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444838289,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444838289,
-    "wof:lastmodified":1566335079,
+    "wof:lastmodified":1566339105,
     "wof:name":"Grafarholt",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -21.758338487215546,
+    -21.75833848721555,
     64.12619089132431,
-    -21.758338487215546,
+    -21.75833848721555,
     64.12619089132431
 ],
   "geometry": {"coordinates":[-21.75833848721555,64.12619089132431],"type":"Point"}

--- a/data/144/483/829/7/1444838297.geojson
+++ b/data/144/483/829/7/1444838297.geojson
@@ -29,13 +29,25 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
-    "wof:geomhash":"a4a700f63c1e6df484d80b7e6f6907f3",
-    "wof:hierarchy":[],
+    "wof:geomhash":"8cd1ed2a971d811d6a1eb4cb0b3430eb",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":-1,
+            "neighbourhood_id":1444838297,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444838297,
-    "wof:lastmodified":1566335079,
+    "wof:lastmodified":1566339106,
     "wof:name":"Ulfarsardalur",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
@@ -45,9 +57,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -21.742030648199677,
+    -21.74203064819968,
     64.13368104469698,
-    -21.742030648199677,
+    -21.74203064819968,
     64.13368104469698
 ],
   "geometry": {"coordinates":[-21.74203064819968,64.13368104469698],"type":"Point"}

--- a/data/144/483/829/7/1444838297.geojson
+++ b/data/144/483/829/7/1444838297.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838297,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.7420306482,64.1336810447,-21.7420306482,64.1336810447",
+    "geom:latitude":64.133681,
+    "geom:longitude":-21.742031,
+    "iso:country":"IS",
+    "lbl:latitude":64.133681,
+    "lbl:longitude":-21.74203,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Ulfarsardalur"
+    ],
+    "name:isl_x_preferred":[
+        "\u00dalfars\u00e1rdalur"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"a4a700f63c1e6df484d80b7e6f6907f3",
+    "wof:hierarchy":[],
+    "wof:id":1444838297,
+    "wof:lastmodified":1566335079,
+    "wof:name":"Ulfarsardalur",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.742030648199677,
+    64.13368104469698,
+    -21.742030648199677,
+    64.13368104469698
+],
+  "geometry": {"coordinates":[-21.74203064819968,64.13368104469698],"type":"Point"}
+}

--- a/data/144/483/831/1/1444838311.geojson
+++ b/data/144/483/831/1/1444838311.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
     "wof:geomhash":"d89250ddaa96b15a02a8b930d446c141",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444838311,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444838311,
-    "wof:lastmodified":1566335079,
+    "wof:lastmodified":1566339107,
     "wof:name":"Grafarvogur",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],

--- a/data/144/483/831/1/1444838311.geojson
+++ b/data/144/483/831/1/1444838311.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838311,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.7912684379,64.1414395395,-21.7912684379,64.1414395395",
+    "geom:latitude":64.14144,
+    "geom:longitude":-21.791268,
+    "iso:country":"IS",
+    "lbl:latitude":64.14144,
+    "lbl:longitude":-21.791268,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":15.0,
+    "mz:min_zoom":12.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Grafarvogur"
+    ],
+    "name:isl_x_preferred":[
+        "Grafarvogur"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"d89250ddaa96b15a02a8b930d446c141",
+    "wof:hierarchy":[],
+    "wof:id":1444838311,
+    "wof:lastmodified":1566335079,
+    "wof:name":"Grafarvogur",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.7912684379299,
+    64.1414395394536,
+    -21.7912684379299,
+    64.1414395394536
+],
+  "geometry": {"coordinates":[-21.7912684379299,64.1414395394536],"type":"Point"}
+}

--- a/data/144/483/832/3/1444838323.geojson
+++ b/data/144/483/832/3/1444838323.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
-    "wof:geomhash":"27bf62d3781afc8a862d17bc13c17862",
-    "wof:hierarchy":[],
+    "wof:geomhash":"7f4ad12f53d3d9649346dace1ce3ac79",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444838323,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444838323,
-    "wof:lastmodified":1566335079,
+    "wof:lastmodified":1566339107,
     "wof:name":"Hofdar",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -21.818791492549664,
+    -21.81879149254966,
     64.12773488305392,
-    -21.818791492549664,
+    -21.81879149254966,
     64.12773488305392
 ],
   "geometry": {"coordinates":[-21.81879149254966,64.12773488305392],"type":"Point"}

--- a/data/144/483/832/3/1444838323.geojson
+++ b/data/144/483/832/3/1444838323.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838323,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.8187914925,64.1277348831,-21.8187914925,64.1277348831",
+    "geom:latitude":64.127735,
+    "geom:longitude":-21.818791,
+    "iso:country":"IS",
+    "lbl:latitude":64.127735,
+    "lbl:longitude":-21.818791,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Hofdar"
+    ],
+    "name:isl_x_preferred":[
+        "H\u00f6f\u00f0ar"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"27bf62d3781afc8a862d17bc13c17862",
+    "wof:hierarchy":[],
+    "wof:id":1444838323,
+    "wof:lastmodified":1566335079,
+    "wof:name":"Hofdar",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.818791492549664,
+    64.12773488305392,
+    -21.818791492549664,
+    64.12773488305392
+],
+  "geometry": {"coordinates":[-21.81879149254966,64.12773488305392],"type":"Point"}
+}

--- a/data/144/483/833/3/1444838333.geojson
+++ b/data/144/483/833/3/1444838333.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838333,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.8182192877,64.1324786056,-21.8182192877,64.1324786056",
+    "geom:latitude":64.132479,
+    "geom:longitude":-21.818219,
+    "iso:country":"IS",
+    "lbl:latitude":64.132479,
+    "lbl:longitude":-21.818219,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Bryggjuhverfi"
+    ],
+    "name:isl_x_preferred":[
+        "Bryggjuhverfi"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"465d1de63504beb07d6feadd276b6073",
+    "wof:hierarchy":[],
+    "wof:id":1444838333,
+    "wof:lastmodified":1566335079,
+    "wof:name":"Bryggjuhverfi",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.818219287671912,
+    64.13247860558833,
+    -21.818219287671912,
+    64.13247860558833
+],
+  "geometry": {"coordinates":[-21.81821928767191,64.13247860558833],"type":"Point"}
+}

--- a/data/144/483/833/3/1444838333.geojson
+++ b/data/144/483/833/3/1444838333.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
-    "wof:geomhash":"465d1de63504beb07d6feadd276b6073",
-    "wof:hierarchy":[],
+    "wof:geomhash":"00b31d37e2e7d572588c39996d4c8d43",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444838333,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444838333,
-    "wof:lastmodified":1566335079,
+    "wof:lastmodified":1566339110,
     "wof:name":"Bryggjuhverfi",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -21.818219287671912,
+    -21.81821928767191,
     64.13247860558833,
-    -21.818219287671912,
+    -21.81821928767191,
     64.13247860558833
 ],
   "geometry": {"coordinates":[-21.81821928767191,64.13247860558833],"type":"Point"}

--- a/data/144/483/834/5/1444838345.geojson
+++ b/data/144/483/834/5/1444838345.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838345,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.8155871452,64.1391683743,-21.8155871452,64.1391683743",
+    "geom:latitude":64.139168,
+    "geom:longitude":-21.815587,
+    "iso:country":"IS",
+    "lbl:latitude":64.139168,
+    "lbl:longitude":-21.815587,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Hamrar"
+    ],
+    "name:isl_x_preferred":[
+        "Hamrar"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"5596b97cc5ef5f30a92d0e7ca78b5118",
+    "wof:hierarchy":[],
+    "wof:id":1444838345,
+    "wof:lastmodified":1566335079,
+    "wof:name":"Hamrar",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.815587145234264,
+    64.1391683742652,
+    -21.815587145234264,
+    64.1391683742652
+],
+  "geometry": {"coordinates":[-21.81558714523426,64.1391683742652],"type":"Point"}
+}

--- a/data/144/483/834/5/1444838345.geojson
+++ b/data/144/483/834/5/1444838345.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
-    "wof:geomhash":"5596b97cc5ef5f30a92d0e7ca78b5118",
-    "wof:hierarchy":[],
+    "wof:geomhash":"e028e0f4cf889874d8c087d086bf55a1",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444838345,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444838345,
-    "wof:lastmodified":1566335079,
+    "wof:lastmodified":1566339111,
     "wof:name":"Hamrar",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -21.815587145234264,
+    -21.81558714523426,
     64.1391683742652,
-    -21.815587145234264,
+    -21.81558714523426,
     64.1391683742652
 ],
   "geometry": {"coordinates":[-21.81558714523426,64.1391683742652],"type":"Point"}

--- a/data/144/483/835/7/1444838357.geojson
+++ b/data/144/483/835/7/1444838357.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838357,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.7987643218,64.1362230776,-21.7987643218,64.1362230776",
+    "geom:latitude":64.136223,
+    "geom:longitude":-21.798764,
+    "iso:country":"IS",
+    "lbl:latitude":64.136223,
+    "lbl:longitude":-21.798764,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Foldir"
+    ],
+    "name:isl_x_preferred":[
+        "Foldir"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"29e4598da44af67b39a9ec7d44012e92",
+    "wof:hierarchy":[],
+    "wof:id":1444838357,
+    "wof:lastmodified":1566335079,
+    "wof:name":"Foldir",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.79876432182842,
+    64.13622307762307,
+    -21.79876432182842,
+    64.13622307762307
+],
+  "geometry": {"coordinates":[-21.79876432182842,64.13622307762307],"type":"Point"}
+}

--- a/data/144/483/835/7/1444838357.geojson
+++ b/data/144/483/835/7/1444838357.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
     "wof:geomhash":"29e4598da44af67b39a9ec7d44012e92",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444838357,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444838357,
-    "wof:lastmodified":1566335079,
+    "wof:lastmodified":1566339112,
     "wof:name":"Foldir",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],

--- a/data/144/483/836/7/1444838367.geojson
+++ b/data/144/483/836/7/1444838367.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
-    "wof:geomhash":"5b1163a5624f77355a30c20e3d4de533",
-    "wof:hierarchy":[],
+    "wof:geomhash":"296f3106a283326977d833ba70c248f7",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444838367,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444838367,
-    "wof:lastmodified":1566335079,
+    "wof:lastmodified":1566339112,
     "wof:name":"H\u00fas",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -21.778851592082724,
+    -21.77885159208272,
     64.13782056540958,
-    -21.778851592082724,
+    -21.77885159208272,
     64.13782056540958
 ],
   "geometry": {"coordinates":[-21.77885159208272,64.13782056540958],"type":"Point"}

--- a/data/144/483/836/7/1444838367.geojson
+++ b/data/144/483/836/7/1444838367.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838367,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.7788515921,64.1378205654,-21.7788515921,64.1378205654",
+    "geom:latitude":64.137821,
+    "geom:longitude":-21.778852,
+    "iso:country":"IS",
+    "lbl:latitude":64.137821,
+    "lbl:longitude":-21.778851,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "H\u00fas"
+    ],
+    "name:isl_x_preferred":[
+        "H\u00fas"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"5b1163a5624f77355a30c20e3d4de533",
+    "wof:hierarchy":[],
+    "wof:id":1444838367,
+    "wof:lastmodified":1566335079,
+    "wof:name":"H\u00fas",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.778851592082724,
+    64.13782056540958,
+    -21.778851592082724,
+    64.13782056540958
+],
+  "geometry": {"coordinates":[-21.77885159208272,64.13782056540958],"type":"Point"}
+}

--- a/data/144/483/837/9/1444838379.geojson
+++ b/data/144/483/837/9/1444838379.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
-    "wof:geomhash":"e905bb4aa9742cf5bf5ba38d22a30003",
-    "wof:hierarchy":[],
+    "wof:geomhash":"f84642ce8a86341723345b9b1c9ca558",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444838379,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444838379,
-    "wof:lastmodified":1566335079,
+    "wof:lastmodified":1566339115,
     "wof:name":"Rimar",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -21.793271155002024,
+    -21.79327115500202,
     64.1454572841593,
-    -21.793271155002024,
+    -21.79327115500202,
     64.1454572841593
 ],
   "geometry": {"coordinates":[-21.79327115500202,64.14545728415931],"type":"Point"}

--- a/data/144/483/837/9/1444838379.geojson
+++ b/data/144/483/837/9/1444838379.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838379,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.793271155,64.1454572842,-21.793271155,64.1454572842",
+    "geom:latitude":64.145457,
+    "geom:longitude":-21.793271,
+    "iso:country":"IS",
+    "lbl:latitude":64.145457,
+    "lbl:longitude":-21.793271,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Rimar"
+    ],
+    "name:isl_x_preferred":[
+        "Rimar"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"e905bb4aa9742cf5bf5ba38d22a30003",
+    "wof:hierarchy":[],
+    "wof:id":1444838379,
+    "wof:lastmodified":1566335079,
+    "wof:name":"Rimar",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.793271155002024,
+    64.1454572841593,
+    -21.793271155002024,
+    64.1454572841593
+],
+  "geometry": {"coordinates":[-21.79327115500202,64.14545728415931],"type":"Point"}
+}

--- a/data/144/483/838/9/1444838389.geojson
+++ b/data/144/483/838/9/1444838389.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838389,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.802540874,64.1429119446,-21.802540874,64.1429119446",
+    "geom:latitude":64.142912,
+    "geom:longitude":-21.802541,
+    "iso:country":"IS",
+    "lbl:latitude":64.142912,
+    "lbl:longitude":-21.80254,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Flatir"
+    ],
+    "name:isl_x_preferred":[
+        "Flatir"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"246e3690d4ac1e5289d10a4238584716",
+    "wof:hierarchy":[],
+    "wof:id":1444838389,
+    "wof:lastmodified":1566335079,
+    "wof:name":"Flatir",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.802540874021567,
+    64.1429119445841,
+    -21.802540874021567,
+    64.1429119445841
+],
+  "geometry": {"coordinates":[-21.80254087402157,64.1429119445841],"type":"Point"}
+}

--- a/data/144/483/838/9/1444838389.geojson
+++ b/data/144/483/838/9/1444838389.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
-    "wof:geomhash":"246e3690d4ac1e5289d10a4238584716",
-    "wof:hierarchy":[],
+    "wof:geomhash":"7b997b8f781320c8b2398fda16c20cb1",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444838389,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444838389,
-    "wof:lastmodified":1566335079,
+    "wof:lastmodified":1566339116,
     "wof:name":"Flatir",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -21.802540874021567,
+    -21.80254087402157,
     64.1429119445841,
-    -21.802540874021567,
+    -21.80254087402157,
     64.1429119445841
 ],
   "geometry": {"coordinates":[-21.80254087402157,64.1429119445841],"type":"Point"}

--- a/data/144/483/840/3/1444838403.geojson
+++ b/data/144/483/840/3/1444838403.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838403,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.7704974009,64.1419137038,-21.7704974009,64.1419137038",
+    "geom:latitude":64.141914,
+    "geom:longitude":-21.770497,
+    "iso:country":"IS",
+    "lbl:latitude":64.141914,
+    "lbl:longitude":-21.770497,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Leynar"
+    ],
+    "name:isl_x_preferred":[
+        "Leynar"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"29339da75fdfba65807fb58771380aca",
+    "wof:hierarchy":[],
+    "wof:id":1444838403,
+    "wof:lastmodified":1566335079,
+    "wof:name":"Leynar",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.770497400867573,
+    64.14191370379854,
+    -21.770497400867573,
+    64.14191370379854
+],
+  "geometry": {"coordinates":[-21.77049740086757,64.14191370379854],"type":"Point"}
+}

--- a/data/144/483/840/3/1444838403.geojson
+++ b/data/144/483/840/3/1444838403.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
-    "wof:geomhash":"29339da75fdfba65807fb58771380aca",
-    "wof:hierarchy":[],
+    "wof:geomhash":"f5716c00f843c7385d0636b85dea10c8",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444838403,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444838403,
-    "wof:lastmodified":1566335079,
+    "wof:lastmodified":1566339117,
     "wof:name":"Leynar",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -21.770497400867573,
+    -21.77049740086757,
     64.14191370379854,
-    -21.770497400867573,
+    -21.77049740086757,
     64.14191370379854
 ],
   "geometry": {"coordinates":[-21.77049740086757,64.14191370379854],"type":"Point"}

--- a/data/144/483/841/3/1444838413.geojson
+++ b/data/144/483/841/3/1444838413.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838413,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.7781649462,64.1482019967,-21.7781649462,64.1482019967",
+    "geom:latitude":64.148202,
+    "geom:longitude":-21.778165,
+    "iso:country":"IS",
+    "lbl:latitude":64.148202,
+    "lbl:longitude":-21.778164,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Engi"
+    ],
+    "name:isl_x_preferred":[
+        "Engi"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"feac062a21337baa140d8863827a7bb5",
+    "wof:hierarchy":[],
+    "wof:id":1444838413,
+    "wof:lastmodified":1566335079,
+    "wof:name":"Engi",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.778164946229428,
+    64.14820199672495,
+    -21.778164946229428,
+    64.14820199672495
+],
+  "geometry": {"coordinates":[-21.77816494622943,64.14820199672495],"type":"Point"}
+}

--- a/data/144/483/841/3/1444838413.geojson
+++ b/data/144/483/841/3/1444838413.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
-    "wof:geomhash":"feac062a21337baa140d8863827a7bb5",
-    "wof:hierarchy":[],
+    "wof:geomhash":"6eaae1e186cdeb37fb2f56685c187acd",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444838413,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444838413,
-    "wof:lastmodified":1566335079,
+    "wof:lastmodified":1566339117,
     "wof:name":"Engi",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -21.778164946229428,
+    -21.77816494622943,
     64.14820199672495,
-    -21.778164946229428,
+    -21.77816494622943,
     64.14820199672495
 ],
   "geometry": {"coordinates":[-21.77816494622943,64.14820199672495],"type":"Point"}

--- a/data/144/483/842/3/1444838423.geojson
+++ b/data/144/483/842/3/1444838423.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838423,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.7910967765,64.1538402821,-21.7910967765,64.1538402821",
+    "geom:latitude":64.15384,
+    "geom:longitude":-21.791097,
+    "iso:country":"IS",
+    "lbl:latitude":64.15384,
+    "lbl:longitude":-21.791096,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Borgir"
+    ],
+    "name:isl_x_preferred":[
+        "Borgir"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"ee06f4242b38ef2535e352dcf8513d7b",
+    "wof:hierarchy":[],
+    "wof:id":1444838423,
+    "wof:lastmodified":1566335079,
+    "wof:name":"Borgir",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.79109677646657,
+    64.15384028206944,
+    -21.79109677646657,
+    64.15384028206944
+],
+  "geometry": {"coordinates":[-21.79109677646657,64.15384028206944],"type":"Point"}
+}

--- a/data/144/483/842/3/1444838423.geojson
+++ b/data/144/483/842/3/1444838423.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
     "wof:geomhash":"ee06f4242b38ef2535e352dcf8513d7b",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444838423,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444838423,
-    "wof:lastmodified":1566335079,
+    "wof:lastmodified":1566339120,
     "wof:name":"Borgir",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],

--- a/data/144/483/843/5/1444838435.geojson
+++ b/data/144/483/843/5/1444838435.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
-    "wof:geomhash":"d6ab99e59272d6b084f3358f5af57611",
-    "wof:hierarchy":[],
+    "wof:geomhash":"cf1b657e91f80a337b5ae17a4351ea49",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444838435,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444838435,
-    "wof:lastmodified":1566335079,
+    "wof:lastmodified":1566339121,
     "wof:name":"Vikur",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -21.776791654522825,
+    -21.77679165452282,
     64.15398995545524,
-    -21.776791654522825,
+    -21.77679165452282,
     64.15398995545524
 ],
   "geometry": {"coordinates":[-21.77679165452282,64.15398995545524],"type":"Point"}

--- a/data/144/483/843/5/1444838435.geojson
+++ b/data/144/483/843/5/1444838435.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838435,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.7767916545,64.1539899555,-21.7767916545,64.1539899555",
+    "geom:latitude":64.15399,
+    "geom:longitude":-21.776792,
+    "iso:country":"IS",
+    "lbl:latitude":64.15399,
+    "lbl:longitude":-21.776791,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Vikur"
+    ],
+    "name:isl_x_preferred":[
+        "Vikur"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"d6ab99e59272d6b084f3358f5af57611",
+    "wof:hierarchy":[],
+    "wof:id":1444838435,
+    "wof:lastmodified":1566335079,
+    "wof:name":"Vikur",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.776791654522825,
+    64.15398995545524,
+    -21.776791654522825,
+    64.15398995545524
+],
+  "geometry": {"coordinates":[-21.77679165452282,64.15398995545524],"type":"Point"}
+}

--- a/data/144/483/845/3/1444838453.geojson
+++ b/data/144/483/845/3/1444838453.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
-    "wof:geomhash":"1bfbffc750d9133d0da047c013a56535",
-    "wof:hierarchy":[],
+    "wof:geomhash":"ea5400c12eb0e98e8e663382389e423e",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444838453,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444838453,
-    "wof:lastmodified":1566335079,
+    "wof:lastmodified":1566339122,
     "wof:name":"Gufenes",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],
@@ -45,9 +58,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -21.816159350112013,
+    -21.81615935011201,
     64.1517946649012,
-    -21.816159350112013,
+    -21.81615935011201,
     64.1517946649012
 ],
   "geometry": {"coordinates":[-21.81615935011201,64.1517946649012],"type":"Point"}

--- a/data/144/483/845/3/1444838453.geojson
+++ b/data/144/483/845/3/1444838453.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838453,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.8161593501,64.1517946649,-21.8161593501,64.1517946649",
+    "geom:latitude":64.151795,
+    "geom:longitude":-21.816159,
+    "iso:country":"IS",
+    "lbl:latitude":64.151795,
+    "lbl:longitude":-21.816159,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Gufenes"
+    ],
+    "name:isl_x_preferred":[
+        "Gufenes"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"1bfbffc750d9133d0da047c013a56535",
+    "wof:hierarchy":[],
+    "wof:id":1444838453,
+    "wof:lastmodified":1566335079,
+    "wof:name":"Gufenes",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.816159350112013,
+    64.1517946649012,
+    -21.816159350112013,
+    64.1517946649012
+],
+  "geometry": {"coordinates":[-21.81615935011201,64.1517946649012],"type":"Point"}
+}

--- a/data/144/483/845/9/1444838459.geojson
+++ b/data/144/483/845/9/1444838459.geojson
@@ -29,15 +29,28 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        101751753,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
     "wof:geomhash":"983c3a4b126db7f54ff6998f54371271",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":101751753,
+            "neighbourhood_id":1444838459,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444838459,
-    "wof:lastmodified":1566335079,
+    "wof:lastmodified":1566339125,
     "wof:name":"Stadir",
-    "wof:parent_id":-1,
+    "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-is",
     "wof:superseded_by":[],

--- a/data/144/483/845/9/1444838459.geojson
+++ b/data/144/483/845/9/1444838459.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838459,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.7584810984,64.1561351853,-21.7584810984,64.1561351853",
+    "geom:latitude":64.156135,
+    "geom:longitude":-21.758481,
+    "iso:country":"IS",
+    "lbl:latitude":64.156135,
+    "lbl:longitude":-21.758481,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Stadir"
+    ],
+    "name:isl_x_preferred":[
+        "Sta\u00f0ir"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"983c3a4b126db7f54ff6998f54371271",
+    "wof:hierarchy":[],
+    "wof:id":1444838459,
+    "wof:lastmodified":1566335079,
+    "wof:name":"Stadir",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.75848109843483,
+    64.1561351852906,
+    -21.75848109843483,
+    64.1561351852906
+],
+  "geometry": {"coordinates":[-21.75848109843483,64.15613518529059],"type":"Point"}
+}

--- a/data/144/483/847/1/1444838471.geojson
+++ b/data/144/483/847/1/1444838471.geojson
@@ -29,13 +29,25 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
     "wof:geomhash":"33b7beb3e8e618e01a59b6c224568a2b",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":-1,
+            "neighbourhood_id":1444838471,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444838471,
-    "wof:lastmodified":1566335079,
+    "wof:lastmodified":1566339125,
     "wof:name":"Geldinganes",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/144/483/847/1/1444838471.geojson
+++ b/data/144/483/847/1/1444838471.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838471,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.8003664955,64.1667591116,-21.8003664955,64.1667591116",
+    "geom:latitude":64.166759,
+    "geom:longitude":-21.800366,
+    "iso:country":"IS",
+    "lbl:latitude":64.166759,
+    "lbl:longitude":-21.800366,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Geldinganes"
+    ],
+    "name:isl_x_preferred":[
+        "Geldinganes"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"33b7beb3e8e618e01a59b6c224568a2b",
+    "wof:hierarchy":[],
+    "wof:id":1444838471,
+    "wof:lastmodified":1566335079,
+    "wof:name":"Geldinganes",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.80036649548612,
+    64.16675911156194,
+    -21.80036649548612,
+    64.16675911156194
+],
+  "geometry": {"coordinates":[-21.80036649548612,64.16675911156194],"type":"Point"}
+}

--- a/data/144/483/848/3/1444838483.geojson
+++ b/data/144/483/848/3/1444838483.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444838483,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.7354212419,64.1882189937,-21.7354212419,64.1882189937",
+    "geom:latitude":64.188219,
+    "geom:longitude":-21.735421,
+    "iso:country":"IS",
+    "lbl:latitude":64.188219,
+    "lbl:longitude":-21.735421,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Alfsnes"
+    ],
+    "name:isl_x_preferred":[
+        "\u00c1lfsnes"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"d845e04aaf2ba931ec5b0be1cf38c8d1",
+    "wof:hierarchy":[],
+    "wof:id":1444838483,
+    "wof:lastmodified":1566335079,
+    "wof:name":"Alfsnes",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.735421241861513,
+    64.18821899374693,
+    -21.735421241861513,
+    64.18821899374693
+],
+  "geometry": {"coordinates":[-21.73542124186151,64.18821899374693],"type":"Point"}
+}

--- a/data/144/483/848/3/1444838483.geojson
+++ b/data/144/483/848/3/1444838483.geojson
@@ -29,13 +29,25 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
-    "wof:geomhash":"d845e04aaf2ba931ec5b0be1cf38c8d1",
-    "wof:hierarchy":[],
+    "wof:geomhash":"36f77830ea80ea137356035b36297c31",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":-1,
+            "neighbourhood_id":1444838483,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444838483,
-    "wof:lastmodified":1566335079,
+    "wof:lastmodified":1566339126,
     "wof:name":"Alfsnes",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
@@ -45,9 +57,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -21.735421241861513,
+    -21.73542124186151,
     64.18821899374693,
-    -21.735421241861513,
+    -21.73542124186151,
     64.18821899374693
 ],
   "geometry": {"coordinates":[-21.73542124186151,64.18821899374693],"type":"Point"}

--- a/data/144/483/849/3/1444838493.geojson
+++ b/data/144/483/849/3/1444838493.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444838493,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.6959391053,64.195792039,-21.6959391053,64.195792039",
+    "geom:latitude":64.195792,
+    "geom:longitude":-21.695939,
+    "iso:country":"IS",
+    "lbl:latitude":64.195792,
+    "lbl:longitude":-21.695939,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Esjumelar"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"be0b895edf5912b6edf1af06999c590b",
+    "wof:hierarchy":[],
+    "wof:id":1444838493,
+    "wof:lastmodified":1566335080,
+    "wof:name":"Esjumelar",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.69593910529677,
+    64.19579203896089,
+    -21.69593910529677,
+    64.19579203896089
+],
+  "geometry": {"coordinates":[-21.69593910529677,64.19579203896089],"type":"Point"}
+}

--- a/data/144/483/849/3/1444838493.geojson
+++ b/data/144/483/849/3/1444838493.geojson
@@ -26,13 +26,25 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
     "wof:geomhash":"be0b895edf5912b6edf1af06999c590b",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":-1,
+            "neighbourhood_id":1444838493,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444838493,
-    "wof:lastmodified":1566335080,
+    "wof:lastmodified":1566339127,
     "wof:name":"Esjumelar",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/144/483/850/3/1444838503.geojson
+++ b/data/144/483/850/3/1444838503.geojson
@@ -26,13 +26,25 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        85633249,
+        85672493
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
-    "wof:geomhash":"990d0c2b1d640a2f2dda951b5b19a09b",
-    "wof:hierarchy":[],
+    "wof:geomhash":"2a8efb22c838969acc97516b5c5a0bc1",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":-1,
+            "neighbourhood_id":1444838503,
+            "region_id":85672493
+        }
+    ],
     "wof:id":1444838503,
-    "wof:lastmodified":1566335080,
+    "wof:lastmodified":1566339130,
     "wof:name":"Grundarhverti",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
@@ -42,9 +54,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -21.834641567663322,
+    -21.83464156766332,
     64.24073923616878,
-    -21.834641567663322,
+    -21.83464156766332,
     64.24073923616878
 ],
   "geometry": {"coordinates":[-21.83464156766332,64.24073923616878],"type":"Point"}

--- a/data/144/483/850/3/1444838503.geojson
+++ b/data/144/483/850/3/1444838503.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444838503,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.8346415677,64.2407392362,-21.8346415677,64.2407392362",
+    "geom:latitude":64.240739,
+    "geom:longitude":-21.834642,
+    "iso:country":"IS",
+    "lbl:latitude":64.240739,
+    "lbl:longitude":-21.834641,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Grundarhverti"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"990d0c2b1d640a2f2dda951b5b19a09b",
+    "wof:hierarchy":[],
+    "wof:id":1444838503,
+    "wof:lastmodified":1566335080,
+    "wof:name":"Grundarhverti",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.834641567663322,
+    64.24073923616878,
+    -21.834641567663322,
+    64.24073923616878
+],
+  "geometry": {"coordinates":[-21.83464156766332,64.24073923616878],"type":"Point"}
+}

--- a/data/144/483/851/3/1444838513.geojson
+++ b/data/144/483/851/3/1444838513.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444838513,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-21.791039556,64.2160845347,-21.791039556,64.2160845347",
+    "geom:latitude":64.216085,
+    "geom:longitude":-21.79104,
+    "iso:country":"IS",
+    "lbl:latitude":64.216084,
+    "lbl:longitude":-21.791039,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Saltvik"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"IS",
+    "wof:geomhash":"6f1ca283ad027037a80a46e990e42ead",
+    "wof:hierarchy":[],
+    "wof:id":1444838513,
+    "wof:lastmodified":1566335080,
+    "wof:name":"Saltvik",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-is",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -21.79103955597879,
+    64.21608453470799,
+    -21.79103955597879,
+    64.21608453470799
+],
+  "geometry": {"coordinates":[-21.79103955597879,64.21608453470799],"type":"Point"}
+}

--- a/data/144/483/851/3/1444838513.geojson
+++ b/data/144/483/851/3/1444838513.geojson
@@ -26,13 +26,24 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        102191581,
+        85633249
+    ],
     "wof:breaches":[],
     "wof:country":"IS",
     "wof:geomhash":"6f1ca283ad027037a80a46e990e42ead",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633249,
+            "locality_id":-1,
+            "neighbourhood_id":1444838513,
+            "region_id":-1
+        }
+    ],
     "wof:id":1444838513,
-    "wof:lastmodified":1566335080,
+    "wof:lastmodified":1566339131,
     "wof:name":"Saltvik",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1695.

This PR contains new neighbourhood records from Nat's neighbourhood import file. 