### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/101/751/745/101751745.geojson
+++ b/data/101/751/745/101751745.geojson
@@ -296,6 +296,9 @@
         "wk:page":"Hafnarfj\u00f6r\u00f0ur"
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"34035afd1a577b06b11803fac96088cf",
     "wof:hierarchy":[
         {
@@ -306,7 +309,7 @@
         }
     ],
     "wof:id":101751745,
-    "wof:lastmodified":1566720483,
+    "wof:lastmodified":1582317862,
     "wof:name":"Hafnafj\u00f6r\u00f0ur",
     "wof:parent_id":85672493,
     "wof:placetype":"locality",

--- a/data/101/751/751/101751751.geojson
+++ b/data/101/751/751/101751751.geojson
@@ -374,6 +374,9 @@
         "wk:page":"Keflav\u00edk"
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"253c2cb51d73951a464616f68d7b3537",
     "wof:hierarchy":[
         {
@@ -387,7 +390,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566720483,
+    "wof:lastmodified":1582317862,
     "wof:name":"Keflav\u00edk",
     "wof:parent_id":85672515,
     "wof:placetype":"locality",

--- a/data/101/751/753/101751753.geojson
+++ b/data/101/751/753/101751753.geojson
@@ -747,6 +747,9 @@
         "wk:page":"Reykjav\u00edk"
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a9105e9a4471034f28a4f7e3913cbcfc",
     "wof:hierarchy":[
         {
@@ -760,7 +763,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566720483,
+    "wof:lastmodified":1582317862,
     "wof:megacity":0,
     "wof:name":"Reykjavik",
     "wof:parent_id":85672493,

--- a/data/101/751/755/101751755.geojson
+++ b/data/101/751/755/101751755.geojson
@@ -254,6 +254,9 @@
         "wk:page":"Akranes"
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"46e685127f90f799dee92c9f1a41513f",
     "wof:hierarchy":[
         {
@@ -267,7 +270,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566720483,
+    "wof:lastmodified":1582317862,
     "wof:name":"Akranes",
     "wof:parent_id":85672529,
     "wof:placetype":"locality",

--- a/data/101/751/757/101751757.geojson
+++ b/data/101/751/757/101751757.geojson
@@ -403,6 +403,9 @@
         "qs_pg:id":533739
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4b175b7b593c949e230822e3a9f2e287",
     "wof:hierarchy":[
         {
@@ -416,7 +419,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566720483,
+    "wof:lastmodified":1582317862,
     "wof:name":"Akureyri",
     "wof:parent_id":85672511,
     "wof:placetype":"locality",

--- a/data/101/752/761/101752761.geojson
+++ b/data/101/752/761/101752761.geojson
@@ -298,6 +298,9 @@
         "wk:page":"K\u00f3pavogur"
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"120beaa2f5108c09f89b3c2871e55930",
     "wof:hierarchy":[
         {
@@ -311,7 +314,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566720479,
+    "wof:lastmodified":1582317861,
     "wof:name":"K\u00f3pavogur",
     "wof:parent_id":85672493,
     "wof:placetype":"locality",

--- a/data/101/803/615/101803615.geojson
+++ b/data/101/803/615/101803615.geojson
@@ -248,6 +248,9 @@
         "wd:id":"Q187251"
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f92661bf5ff2c1ce8357396cd9c0c5c1",
     "wof:hierarchy":[
         {
@@ -261,7 +264,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566720482,
+    "wof:lastmodified":1582317862,
     "wof:name":"Vestmannaeyjar",
     "wof:parent_id":85672519,
     "wof:placetype":"locality",

--- a/data/101/803/619/101803619.geojson
+++ b/data/101/803/619/101803619.geojson
@@ -118,6 +118,9 @@
         "wk:page":"Hvolsv\u00f6llur"
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"43083735e938f682bd035c8a1a4fde61",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":101803619,
-    "wof:lastmodified":1566720481,
+    "wof:lastmodified":1582317862,
     "wof:name":"Hvolsv\u00f6llur",
     "wof:parent_id":85672519,
     "wof:placetype":"locality",

--- a/data/101/803/621/101803621.geojson
+++ b/data/101/803/621/101803621.geojson
@@ -274,6 +274,9 @@
         "wk:page":"H\u00f6fn"
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"051c9f764c76aae5e627157d2441df1f",
     "wof:hierarchy":[
         {
@@ -282,7 +285,7 @@
         }
     ],
     "wof:id":101803621,
-    "wof:lastmodified":1566720481,
+    "wof:lastmodified":1582317862,
     "wof:name":"H\u00f6fn",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/101/803/623/101803623.geojson
+++ b/data/101/803/623/101803623.geojson
@@ -104,6 +104,9 @@
         "wk:page":"Stokkseyri"
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"00abfadb5e5f1c604fbaea3931469197",
     "wof:hierarchy":[
         {
@@ -112,7 +115,7 @@
         }
     ],
     "wof:id":101803623,
-    "wof:lastmodified":1566720482,
+    "wof:lastmodified":1582317862,
     "wof:name":"Stokkseyri",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/101/803/625/101803625.geojson
+++ b/data/101/803/625/101803625.geojson
@@ -279,6 +279,9 @@
         "wk:page":"Selfoss (town)"
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"74d9b354a5515fa2f107a2d9f672e27c",
     "wof:hierarchy":[
         {
@@ -289,7 +292,7 @@
         }
     ],
     "wof:id":101803625,
-    "wof:lastmodified":1566720482,
+    "wof:lastmodified":1582317862,
     "wof:name":"Selfoss",
     "wof:parent_id":85672519,
     "wof:placetype":"locality",

--- a/data/101/803/627/101803627.geojson
+++ b/data/101/803/627/101803627.geojson
@@ -134,6 +134,9 @@
         "wk:page":"Kirkjub\u00e6jarklaustur"
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"05cd6418393fdb88947f4a342f26fc79",
     "wof:hierarchy":[
         {
@@ -144,7 +147,7 @@
         }
     ],
     "wof:id":101803627,
-    "wof:lastmodified":1566720482,
+    "wof:lastmodified":1582317862,
     "wof:name":"Kirkjub\u00e6jarklaustur",
     "wof:parent_id":85672519,
     "wof:placetype":"locality",

--- a/data/101/803/631/101803631.geojson
+++ b/data/101/803/631/101803631.geojson
@@ -126,6 +126,9 @@
         "wk:page":"Eskifj\u00f6r\u00f0ur"
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f3028cb02dceba2cef88f74a6b973e8c",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
         }
     ],
     "wof:id":101803631,
-    "wof:lastmodified":1566720483,
+    "wof:lastmodified":1582317862,
     "wof:name":"Eskifj\u00f6r\u00f0ur",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/101/803/641/101803641.geojson
+++ b/data/101/803/641/101803641.geojson
@@ -112,6 +112,9 @@
         "wd:id":"Q1413838"
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0deab3bc1fd80705468c5a95260860a4",
     "wof:hierarchy":[
         {
@@ -122,7 +125,7 @@
         }
     ],
     "wof:id":101803641,
-    "wof:lastmodified":1566720482,
+    "wof:lastmodified":1582317862,
     "wof:name":"Laugarvatn",
     "wof:parent_id":85672519,
     "wof:placetype":"locality",

--- a/data/101/803/645/101803645.geojson
+++ b/data/101/803/645/101803645.geojson
@@ -79,6 +79,9 @@
         "qs_pg:id":276819
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"db0db157cd5afb60d04298a4ece622e3",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
         }
     ],
     "wof:id":101803645,
-    "wof:lastmodified":1566720481,
+    "wof:lastmodified":1582317862,
     "wof:name":"Reykholt",
     "wof:parent_id":85672519,
     "wof:placetype":"locality",

--- a/data/101/803/649/101803649.geojson
+++ b/data/101/803/649/101803649.geojson
@@ -290,6 +290,9 @@
         "wk:page":"Borgarnes"
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"899e0382fdf1e7037996e7cd6c81c995",
     "wof:hierarchy":[
         {
@@ -298,7 +301,7 @@
         }
     ],
     "wof:id":101803649,
-    "wof:lastmodified":1566720482,
+    "wof:lastmodified":1582317862,
     "wof:name":"Borgarnes",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/101/803/655/101803655.geojson
+++ b/data/101/803/655/101803655.geojson
@@ -148,6 +148,9 @@
         "wk:page":"Stykkish\u00f3lmur"
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"81e49f9412a0c17c748cf9127637cf6b",
     "wof:hierarchy":[
         {
@@ -158,7 +161,7 @@
         }
     ],
     "wof:id":101803655,
-    "wof:lastmodified":1566720483,
+    "wof:lastmodified":1582317862,
     "wof:name":"Stykkish\u00f3lmur",
     "wof:parent_id":85672529,
     "wof:placetype":"locality",

--- a/data/101/803/657/101803657.geojson
+++ b/data/101/803/657/101803657.geojson
@@ -107,6 +107,9 @@
         "wk:page":"Hellissandur"
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2f5372df63debb51782a71a83ce01ecb",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
         }
     ],
     "wof:id":101803657,
-    "wof:lastmodified":1566720482,
+    "wof:lastmodified":1582317862,
     "wof:name":"Hellissandur",
     "wof:parent_id":85672529,
     "wof:placetype":"locality",

--- a/data/101/803/659/101803659.geojson
+++ b/data/101/803/659/101803659.geojson
@@ -177,6 +177,9 @@
         "wk:page":"Dalv\u00edk"
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"60af60d1ed5ff0660e4424f4e6a2f442",
     "wof:hierarchy":[
         {
@@ -187,7 +190,7 @@
         }
     ],
     "wof:id":101803659,
-    "wof:lastmodified":1566720482,
+    "wof:lastmodified":1582317862,
     "wof:name":"Dalv\u00edk",
     "wof:parent_id":85672511,
     "wof:placetype":"locality",

--- a/data/101/803/661/101803661.geojson
+++ b/data/101/803/661/101803661.geojson
@@ -127,6 +127,9 @@
         "wk:page":"Skagastr\u00f6nd"
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"beca3a988b7baed2b6122c457ab4699b",
     "wof:hierarchy":[
         {
@@ -137,7 +140,7 @@
         }
     ],
     "wof:id":101803661,
-    "wof:lastmodified":1566720482,
+    "wof:lastmodified":1582317862,
     "wof:name":"Skagastr\u00f6nd",
     "wof:parent_id":85672507,
     "wof:placetype":"locality",

--- a/data/101/803/663/101803663.geojson
+++ b/data/101/803/663/101803663.geojson
@@ -154,6 +154,9 @@
         "wk:page":"Nor\u00f0ur\u00feing"
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3b0639ba1e951198691ab50d97c81a40",
     "wof:hierarchy":[
         {
@@ -167,7 +170,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566720483,
+    "wof:lastmodified":1582317862,
     "wof:name":"H\u00fasav\u00edk",
     "wof:parent_id":85672511,
     "wof:placetype":"locality",

--- a/data/101/803/665/101803665.geojson
+++ b/data/101/803/665/101803665.geojson
@@ -104,6 +104,9 @@
         "wk:page":"Raufarh\u00f6fn"
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e208df12e8b86b662824143534d7082c",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":101803665,
-    "wof:lastmodified":1566720483,
+    "wof:lastmodified":1582317862,
     "wof:name":"Raufarh\u00f6fn",
     "wof:parent_id":85672511,
     "wof:placetype":"locality",

--- a/data/101/803/667/101803667.geojson
+++ b/data/101/803/667/101803667.geojson
@@ -144,6 +144,9 @@
         "qs_pg:id":1079779
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5a92e89155c8c513732e5e19d325188c",
     "wof:hierarchy":[
         {
@@ -154,7 +157,7 @@
         }
     ],
     "wof:id":101803667,
-    "wof:lastmodified":1566720482,
+    "wof:lastmodified":1582317862,
     "wof:name":"Siglufj\u00f6r\u00f0ur",
     "wof:parent_id":85672511,
     "wof:placetype":"locality",

--- a/data/101/803/669/101803669.geojson
+++ b/data/101/803/669/101803669.geojson
@@ -123,6 +123,9 @@
         "wk:page":"\u00d3lafsfj\u00f6r\u00f0ur"
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"34b8164fa284f9af9598455d1156c21e",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":101803669,
-    "wof:lastmodified":1566720482,
+    "wof:lastmodified":1582317862,
     "wof:name":"\u00d3lafsfj\u00f6r\u00f0ur",
     "wof:parent_id":85672511,
     "wof:placetype":"locality",

--- a/data/101/803/673/101803673.geojson
+++ b/data/101/803/673/101803673.geojson
@@ -97,6 +97,9 @@
         "wk:page":"Hofs\u00f3s"
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d238ccd106e03b15ad4a1fcf14fad4fd",
     "wof:hierarchy":[
         {
@@ -107,7 +110,7 @@
         }
     ],
     "wof:id":101803673,
-    "wof:lastmodified":1566720481,
+    "wof:lastmodified":1582317862,
     "wof:name":"Hofs\u00f3s",
     "wof:parent_id":85672507,
     "wof:placetype":"locality",

--- a/data/101/803/675/101803675.geojson
+++ b/data/101/803/675/101803675.geojson
@@ -93,6 +93,9 @@
         "wk:page":"Reykh\u00f3lar"
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"049ec18328b6e8fca4efc49749e67ae5",
     "wof:hierarchy":[
         {
@@ -103,7 +106,7 @@
         }
     ],
     "wof:id":101803675,
-    "wof:lastmodified":1566720481,
+    "wof:lastmodified":1582317861,
     "wof:name":"Reykh\u00f3lar",
     "wof:parent_id":85672497,
     "wof:placetype":"locality",

--- a/data/101/803/677/101803677.geojson
+++ b/data/101/803/677/101803677.geojson
@@ -116,6 +116,9 @@
         "wk:page":"H\u00f3lmav\u00edk"
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a51cf7e190d19b4b8c96ab1b0bb665ad",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":101803677,
-    "wof:lastmodified":1566720482,
+    "wof:lastmodified":1582317862,
     "wof:name":"H\u00f3lmav\u00edk",
     "wof:parent_id":85672497,
     "wof:placetype":"locality",

--- a/data/101/803/681/101803681.geojson
+++ b/data/101/803/681/101803681.geojson
@@ -84,6 +84,9 @@
         "wk:page":"Hn\u00edfsdalur"
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c835352172077a52ea4085031659986e",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
         }
     ],
     "wof:id":101803681,
-    "wof:lastmodified":1566720481,
+    "wof:lastmodified":1582317862,
     "wof:name":"Hn\u00edfsdalur",
     "wof:parent_id":85672497,
     "wof:placetype":"locality",

--- a/data/101/803/683/101803683.geojson
+++ b/data/101/803/683/101803683.geojson
@@ -347,6 +347,9 @@
         "qs_pg:id":1104591
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c221d997b661453867b2dfb7307f406b",
     "wof:hierarchy":[
         {
@@ -357,7 +360,7 @@
         }
     ],
     "wof:id":101803683,
-    "wof:lastmodified":1566720482,
+    "wof:lastmodified":1582317862,
     "wof:name":"\u00cdsafj\u00f6r\u00f0ur",
     "wof:parent_id":85672497,
     "wof:placetype":"locality",

--- a/data/101/803/685/101803685.geojson
+++ b/data/101/803/685/101803685.geojson
@@ -151,6 +151,9 @@
         "wk:page":"Bolungarv\u00edk"
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"297fa02f34f1bcb29f2e4d222c12ebe0",
     "wof:hierarchy":[
         {
@@ -161,7 +164,7 @@
         }
     ],
     "wof:id":101803685,
-    "wof:lastmodified":1566720482,
+    "wof:lastmodified":1582317862,
     "wof:name":"Bolungarv\u00edk",
     "wof:parent_id":85672497,
     "wof:placetype":"locality",

--- a/data/101/845/631/101845631.geojson
+++ b/data/101/845/631/101845631.geojson
@@ -151,6 +151,9 @@
         "wk:page":"V\u00edk \u00ed M\u00fdrdal"
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c4cfd4f2f65e80514462c19a3e67c665",
     "wof:hierarchy":[
         {
@@ -159,7 +162,7 @@
         }
     ],
     "wof:id":101845631,
-    "wof:lastmodified":1566720481,
+    "wof:lastmodified":1582317861,
     "wof:name":"V\u00edk",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/101/845/633/101845633.geojson
+++ b/data/101/845/633/101845633.geojson
@@ -119,6 +119,9 @@
         "wk:page":"Hella, Iceland"
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5752c1a047c0eba27b7c24b49a48399c",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":101845633,
-    "wof:lastmodified":1566720480,
+    "wof:lastmodified":1582317861,
     "wof:name":"Hella",
     "wof:parent_id":85672519,
     "wof:placetype":"locality",

--- a/data/101/845/635/101845635.geojson
+++ b/data/101/845/635/101845635.geojson
@@ -101,6 +101,9 @@
         "wk:page":"Eyrarbakki"
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"58b92628690cb1a94b872adfdfbaa435",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
         }
     ],
     "wof:id":101845635,
-    "wof:lastmodified":1566720480,
+    "wof:lastmodified":1582317861,
     "wof:name":"Eyrarbakki",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/101/845/643/101845643.geojson
+++ b/data/101/845/643/101845643.geojson
@@ -183,6 +183,9 @@
         "qs_pg:id":1079778
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f0d4196de7b505244cbba169013e6dac",
     "wof:hierarchy":[
         {
@@ -193,7 +196,7 @@
         }
     ],
     "wof:id":101845643,
-    "wof:lastmodified":1566720480,
+    "wof:lastmodified":1582317861,
     "wof:name":"Sey\u00f0isfj\u00f6r\u00f0ur",
     "wof:parent_id":85672501,
     "wof:placetype":"locality",

--- a/data/101/845/645/101845645.geojson
+++ b/data/101/845/645/101845645.geojson
@@ -193,6 +193,9 @@
         "wk:page":"Grindav\u00edk"
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"668587a589f1dd1924eb16a38f95bb8d",
     "wof:hierarchy":[
         {
@@ -203,7 +206,7 @@
         }
     ],
     "wof:id":101845645,
-    "wof:lastmodified":1566720480,
+    "wof:lastmodified":1582317861,
     "wof:name":"Grindav\u00edk",
     "wof:parent_id":85672515,
     "wof:placetype":"locality",

--- a/data/101/845/649/101845649.geojson
+++ b/data/101/845/649/101845649.geojson
@@ -132,6 +132,9 @@
         "wk:page":"Vogar"
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e03980e3e596f89adfab3251ab8e025b",
     "wof:hierarchy":[
         {
@@ -142,7 +145,7 @@
         }
     ],
     "wof:id":101845649,
-    "wof:lastmodified":1566720480,
+    "wof:lastmodified":1582317861,
     "wof:name":"Vogar",
     "wof:parent_id":85672515,
     "wof:placetype":"locality",

--- a/data/101/845/651/101845651.geojson
+++ b/data/101/845/651/101845651.geojson
@@ -166,6 +166,9 @@
         "wk:page":"\u00c1lftanes"
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"86e4df8d0588f08f42778ccda4e951bf",
     "wof:hierarchy":[
         {
@@ -176,7 +179,7 @@
         }
     ],
     "wof:id":101845651,
-    "wof:lastmodified":1566720480,
+    "wof:lastmodified":1582317861,
     "wof:name":"\u00c1lftanes",
     "wof:parent_id":85672493,
     "wof:placetype":"locality",

--- a/data/101/845/657/101845657.geojson
+++ b/data/101/845/657/101845657.geojson
@@ -197,6 +197,9 @@
         "qs_pg:id":918237
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c80f1bd40b526e7672c418c02bf5fee9",
     "wof:hierarchy":[
         {
@@ -207,7 +210,7 @@
         }
     ],
     "wof:id":101845657,
-    "wof:lastmodified":1566720480,
+    "wof:lastmodified":1582317861,
     "wof:name":"Egilssta\u00f0ir",
     "wof:parent_id":85672501,
     "wof:placetype":"locality",

--- a/data/101/845/661/101845661.geojson
+++ b/data/101/845/661/101845661.geojson
@@ -118,6 +118,9 @@
         "wk:page":"Reykjahl\u00ed\u00f0"
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4a6d45e24c20712eb21501896ccf9ba3",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":101845661,
-    "wof:lastmodified":1566720480,
+    "wof:lastmodified":1582317861,
     "wof:name":"Reykjahl\u00ed\u00f0",
     "wof:parent_id":85672511,
     "wof:placetype":"locality",

--- a/data/101/845/663/101845663.geojson
+++ b/data/101/845/663/101845663.geojson
@@ -136,6 +136,9 @@
         "wk:page":"\u00d3lafsv\u00edk"
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"267313c3123a7504d755f9eab8533065",
     "wof:hierarchy":[
         {
@@ -146,7 +149,7 @@
         }
     ],
     "wof:id":101845663,
-    "wof:lastmodified":1566720481,
+    "wof:lastmodified":1582317861,
     "wof:name":"\u00d3lafsv\u00edk",
     "wof:parent_id":85672529,
     "wof:placetype":"locality",

--- a/data/101/845/667/101845667.geojson
+++ b/data/101/845/667/101845667.geojson
@@ -168,6 +168,9 @@
         "qs_pg:id":1091431
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f8a99f587c62c3f9ac1426c1b2ad00ab",
     "wof:hierarchy":[
         {
@@ -178,7 +181,7 @@
         }
     ],
     "wof:id":101845667,
-    "wof:lastmodified":1566720480,
+    "wof:lastmodified":1582317861,
     "wof:name":"Rif",
     "wof:parent_id":85672529,
     "wof:placetype":"locality",

--- a/data/101/845/673/101845673.geojson
+++ b/data/101/845/673/101845673.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Hvammstangi"
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6348fee5f3244d63088e36bc300c77a6",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":101845673,
-    "wof:lastmodified":1566720480,
+    "wof:lastmodified":1582317861,
     "wof:name":"Hvammstangi",
     "wof:parent_id":85672507,
     "wof:placetype":"locality",

--- a/data/101/845/679/101845679.geojson
+++ b/data/101/845/679/101845679.geojson
@@ -118,6 +118,9 @@
         "wd:id":"Q337924"
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9d043864467791ae96cc5b3c4ad9b8a8",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":101845679,
-    "wof:lastmodified":1566720481,
+    "wof:lastmodified":1582317861,
     "wof:name":"Greniv\u00edk",
     "wof:parent_id":85672511,
     "wof:placetype":"locality",

--- a/data/101/845/681/101845681.geojson
+++ b/data/101/845/681/101845681.geojson
@@ -281,6 +281,9 @@
         "qs_pg:id":1079776
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f5899362b98ed062fd2e0034886adc06",
     "wof:hierarchy":[
         {
@@ -291,7 +294,7 @@
         }
     ],
     "wof:id":101845681,
-    "wof:lastmodified":1566720480,
+    "wof:lastmodified":1582317861,
     "wof:name":"Sau\u00f0\u00e1rkr\u00f3kur",
     "wof:parent_id":85672507,
     "wof:placetype":"locality",

--- a/data/101/845/689/101845689.geojson
+++ b/data/101/845/689/101845689.geojson
@@ -112,6 +112,9 @@
         "wk:page":"Patreksfj\u00f6r\u00f0ur"
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2c368fda4a9f149568ac98ca83b49105",
     "wof:hierarchy":[
         {
@@ -122,7 +125,7 @@
         }
     ],
     "wof:id":101845689,
-    "wof:lastmodified":1566720480,
+    "wof:lastmodified":1582317861,
     "wof:name":"Patreksfj\u00f6r\u00f0ur",
     "wof:parent_id":85672497,
     "wof:placetype":"locality",

--- a/data/101/845/691/101845691.geojson
+++ b/data/101/845/691/101845691.geojson
@@ -93,6 +93,9 @@
         "wk:page":"Flateyri"
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a882032865575a404d3ec5837a3730dc",
     "wof:hierarchy":[
         {
@@ -101,7 +104,7 @@
         }
     ],
     "wof:id":101845691,
-    "wof:lastmodified":1566720481,
+    "wof:lastmodified":1582317861,
     "wof:name":"Flateyri",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/101/845/693/101845693.geojson
+++ b/data/101/845/693/101845693.geojson
@@ -100,6 +100,9 @@
         "wk:page":"Su\u00f0ureyri"
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2f19c20cbf789026607866cf66d329a0",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
         }
     ],
     "wof:id":101845693,
-    "wof:lastmodified":1566720480,
+    "wof:lastmodified":1582317861,
     "wof:name":"Su\u00f0ureyri",
     "wof:parent_id":85672497,
     "wof:placetype":"locality",

--- a/data/101/870/527/101870527.geojson
+++ b/data/101/870/527/101870527.geojson
@@ -70,6 +70,9 @@
         "wd:id":"Q6529399"
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b8326b6601d774458404b9ee41698466",
     "wof:hierarchy":[
         {
@@ -80,7 +83,7 @@
         }
     ],
     "wof:id":101870527,
-    "wof:lastmodified":1566720484,
+    "wof:lastmodified":1582317863,
     "wof:name":"Svalbar\u00f0seyri",
     "wof:parent_id":85672511,
     "wof:placetype":"locality",

--- a/data/101/870/529/101870529.geojson
+++ b/data/101/870/529/101870529.geojson
@@ -175,6 +175,9 @@
         "wk:page":"Bl\u00f6ndu\u00f3s"
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a62083476f0cd57dc5bea4a12b21c5bb",
     "wof:hierarchy":[
         {
@@ -185,7 +188,7 @@
         }
     ],
     "wof:id":101870529,
-    "wof:lastmodified":1566720484,
+    "wof:lastmodified":1582317863,
     "wof:name":"Bl\u00f6ndu\u00f3s",
     "wof:parent_id":85672507,
     "wof:placetype":"locality",

--- a/data/101/870/531/101870531.geojson
+++ b/data/101/870/531/101870531.geojson
@@ -113,6 +113,10 @@
         "wk:page":"Hafnir"
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"c2769ae25c129dc9d04cf4e65d28dfa8",
     "wof:hierarchy":[
         {
@@ -123,7 +127,7 @@
         }
     ],
     "wof:id":101870531,
-    "wof:lastmodified":1566720484,
+    "wof:lastmodified":1582317863,
     "wof:name":"Hafnir",
     "wof:parent_id":85672515,
     "wof:placetype":"locality",

--- a/data/101/870/533/101870533.geojson
+++ b/data/101/870/533/101870533.geojson
@@ -52,6 +52,10 @@
         "qs_pg:id":217607
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1c03a1340f6650e8a4c50141b9fb376e",
     "wof:hierarchy":[
         {
@@ -62,7 +66,7 @@
         }
     ],
     "wof:id":101870533,
-    "wof:lastmodified":1566720483,
+    "wof:lastmodified":1582317862,
     "wof:name":"Grundarhverfi",
     "wof:parent_id":85672493,
     "wof:placetype":"locality",

--- a/data/101/870/535/101870535.geojson
+++ b/data/101/870/535/101870535.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":889374
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3cca1ef6cb102d01fa39ff300e473706",
     "wof:hierarchy":[
         {
@@ -79,7 +83,7 @@
         }
     ],
     "wof:id":101870535,
-    "wof:lastmodified":1566720483,
+    "wof:lastmodified":1582317862,
     "wof:name":"Hrafnagil",
     "wof:parent_id":85672511,
     "wof:placetype":"locality",

--- a/data/101/870/537/101870537.geojson
+++ b/data/101/870/537/101870537.geojson
@@ -110,6 +110,10 @@
         "qs_pg:id":1152376
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e406fdea2e0097b925e64015e7bcc90c",
     "wof:hierarchy":[
         {
@@ -120,7 +124,7 @@
         }
     ],
     "wof:id":101870537,
-    "wof:lastmodified":1566720484,
+    "wof:lastmodified":1582317863,
     "wof:name":"Hvanneyri",
     "wof:parent_id":85672529,
     "wof:placetype":"locality",

--- a/data/101/870/539/101870539.geojson
+++ b/data/101/870/539/101870539.geojson
@@ -64,6 +64,9 @@
         "wd:id":"Q591322"
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"537c8a6e96173ea62b9d38d78b36efbe",
     "wof:hierarchy":[
         {
@@ -74,7 +77,7 @@
         }
     ],
     "wof:id":101870539,
-    "wof:lastmodified":1566720484,
+    "wof:lastmodified":1582317863,
     "wof:name":"Hauganes",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/101/870/543/101870543.geojson
+++ b/data/101/870/543/101870543.geojson
@@ -94,6 +94,10 @@
         "wk:page":"K\u00f3pasker"
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4c38e7a0a0cd39c80c7a65b41540f00e",
     "wof:hierarchy":[
         {
@@ -104,7 +108,7 @@
         }
     ],
     "wof:id":101870543,
-    "wof:lastmodified":1566720483,
+    "wof:lastmodified":1582317862,
     "wof:name":"K\u00f3pasker",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/101/870/545/101870545.geojson
+++ b/data/101/870/545/101870545.geojson
@@ -84,6 +84,9 @@
         "wd:id":"Q1337557"
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b51546d87a0ae42ef90c6bfe68b08d58",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
         }
     ],
     "wof:id":101870545,
-    "wof:lastmodified":1566720484,
+    "wof:lastmodified":1582317863,
     "wof:name":"T\u00e1lknafj\u00f6r\u00f0ur",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/101/870/547/101870547.geojson
+++ b/data/101/870/547/101870547.geojson
@@ -95,6 +95,10 @@
         "wk:page":"B\u00edldudalur"
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5997d05259588230d4d765ae622b14fc",
     "wof:hierarchy":[
         {
@@ -105,7 +109,7 @@
         }
     ],
     "wof:id":101870547,
-    "wof:lastmodified":1566720484,
+    "wof:lastmodified":1582317863,
     "wof:name":"B\u00edldudalur",
     "wof:parent_id":85672497,
     "wof:placetype":"locality",

--- a/data/101/870/549/101870549.geojson
+++ b/data/101/870/549/101870549.geojson
@@ -131,6 +131,10 @@
         "wk:page":"S\u00fa\u00f0av\u00edk"
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"1ea9f5472d76fd7d9692d3d9bd1cd89d",
     "wof:hierarchy":[
         {
@@ -141,7 +145,7 @@
         }
     ],
     "wof:id":101870549,
-    "wof:lastmodified":1566720484,
+    "wof:lastmodified":1582317863,
     "wof:name":"S\u00fa\u00f0av\u00edk",
     "wof:parent_id":85672497,
     "wof:placetype":"locality",

--- a/data/101/872/907/101872907.geojson
+++ b/data/101/872/907/101872907.geojson
@@ -135,6 +135,10 @@
         "wk:page":"Dj\u00fapivogur"
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"b2b98af148433198c0f432075784da28",
     "wof:hierarchy":[
         {
@@ -145,7 +149,7 @@
         }
     ],
     "wof:id":101872907,
-    "wof:lastmodified":1566720481,
+    "wof:lastmodified":1582317861,
     "wof:name":"Dj\u00fapivogur",
     "wof:parent_id":85672501,
     "wof:placetype":"locality",

--- a/data/101/872/909/101872909.geojson
+++ b/data/101/872/909/101872909.geojson
@@ -92,6 +92,10 @@
         "qs_pg:id":575364
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"de1beda1bc69488bf5042e4e83a84070",
     "wof:hierarchy":[
         {
@@ -102,7 +106,7 @@
         }
     ],
     "wof:id":101872909,
-    "wof:lastmodified":1566720481,
+    "wof:lastmodified":1582317861,
     "wof:name":"Brei\u00f0dalsv\u00edk",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/101/872/911/101872911.geojson
+++ b/data/101/872/911/101872911.geojson
@@ -143,6 +143,9 @@
         "wk:page":"Rey\u00f0arfj\u00f6r\u00f0ur"
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9d5b340b81cb7c8331be8ffe6b109f40",
     "wof:hierarchy":[
         {
@@ -153,7 +156,7 @@
         }
     ],
     "wof:id":101872911,
-    "wof:lastmodified":1566720481,
+    "wof:lastmodified":1582317861,
     "wof:name":"Rey\u00f0arfj\u00f6r\u00f0ur",
     "wof:parent_id":85672501,
     "wof:placetype":"locality",

--- a/data/101/911/003/101911003.geojson
+++ b/data/101/911/003/101911003.geojson
@@ -92,6 +92,9 @@
         "wk:page":"Brei\u00f0dalsv\u00edk"
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"681338cce37060cbdf4bc509ea16df69",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
         }
     ],
     "wof:id":101911003,
-    "wof:lastmodified":1566720484,
+    "wof:lastmodified":1582317863,
     "wof:name":"Brei\u00ffdalsv\u00edk",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/101/911/007/101911007.geojson
+++ b/data/101/911/007/101911007.geojson
@@ -49,6 +49,9 @@
         "qs_pg:id":216130
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fef2a80f69c53fe08a7fd738c76a51a9",
     "wof:hierarchy":[
         {
@@ -59,7 +62,7 @@
         }
     ],
     "wof:id":101911007,
-    "wof:lastmodified":1566720484,
+    "wof:lastmodified":1582317863,
     "wof:name":"Svalbaroseyri",
     "wof:parent_id":85672511,
     "wof:placetype":"locality",

--- a/data/101/911/009/101911009.geojson
+++ b/data/101/911/009/101911009.geojson
@@ -84,6 +84,9 @@
         "wd:id":"Q1337557"
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"642f861684bad6c36ff12d77dedd6f62",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
         }
     ],
     "wof:id":101911009,
-    "wof:lastmodified":1566720484,
+    "wof:lastmodified":1582317863,
     "wof:name":"Talknafjordur",
     "wof:parent_id":85672497,
     "wof:placetype":"locality",

--- a/data/101/911/603/101911603.geojson
+++ b/data/101/911/603/101911603.geojson
@@ -47,6 +47,9 @@
         "qs_pg:id":215079
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4ea63e5b8c1496a434cdd340ef9d4c61",
     "wof:hierarchy":[
         {
@@ -57,7 +60,7 @@
         }
     ],
     "wof:id":101911603,
-    "wof:lastmodified":1566720484,
+    "wof:lastmodified":1582317863,
     "wof:name":"Pyrill",
     "wof:parent_id":85672529,
     "wof:placetype":"locality",

--- a/data/101/912/597/101912597.geojson
+++ b/data/101/912/597/101912597.geojson
@@ -46,6 +46,9 @@
         "qs_pg:id":1195601
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"29bb6f7449a69e10dbecce455e6d0bad",
     "wof:hierarchy":[
         {
@@ -54,7 +57,7 @@
         }
     ],
     "wof:id":101912597,
-    "wof:lastmodified":1566720483,
+    "wof:lastmodified":1582317862,
     "wof:name":"B\u00fa\u00ffareyri",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/856/332/49/85633249.geojson
+++ b/data/856/332/49/85633249.geojson
@@ -1134,6 +1134,11 @@
     },
     "wof:country":"IS",
     "wof:country_alpha3":"ISL",
+    "wof:geom_alt":[
+        "naturalearth",
+        "quattroshapes",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"d15756625d7109f8fce8c3c21841280e",
     "wof:hierarchy":[
         {
@@ -1148,7 +1153,7 @@
     "wof:lang_x_spoken":[
         "isl"
     ],
-    "wof:lastmodified":1566720473,
+    "wof:lastmodified":1582317859,
     "wof:name":"Iceland",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/858/021/15/85802115.geojson
+++ b/data/858/021/15/85802115.geojson
@@ -74,6 +74,10 @@
         "qs_pg:id":533763
     },
     "wof:country":"IS",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"62e5d76f328264c9f6763d18c259f5ba",
     "wof:hierarchy":[
         {
@@ -88,7 +92,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566720474,
+    "wof:lastmodified":1582317861,
     "wof:name":"Gr\u00edmssta\u00ffaholt",
     "wof:parent_id":101751753,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.