### PR TITLE
is concordances, placetype local, and more

### DIFF
--- a/data/112/528/232/5/1125282325.geojson
+++ b/data/112/528/232/5/1125282325.geojson
@@ -13,13 +13,19 @@
     "gn:fcode":"ADMD",
     "gn:population":0,
     "iso:country":"IS",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:bbox":"-15.6,64.23333,-15.4,64.43333",
     "lbl:latitude":64.33333,
     "lbl:longitude":-15.5,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
     "qs_pg:aaroncc":"IS",
@@ -47,7 +53,7 @@
     },
     "wof:country":"IS",
     "wof:created":1497042550,
-    "wof:geomhash":"ffbb98fab2eaf64511f2c7607d52399d",
+    "wof:geomhash":"3f91ce6b048c3adc2da0c22fef99d057",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -57,7 +63,7 @@
         }
     ],
     "wof:id":1125282325,
-    "wof:lastmodified":1566720486,
+    "wof:lastmodified":1696022867,
     "wof:name":"Sveitarf\u00e9lagi\u00f0 Hornafj\u00f6r\u00f0ur",
     "wof:parent_id":85672501,
     "wof:placetype":"localadmin",

--- a/data/112/528/957/3/1125289573.geojson
+++ b/data/112/528/957/3/1125289573.geojson
@@ -13,13 +13,19 @@
     "gn:fcode":"ADMD",
     "gn:population":0,
     "iso:country":"IS",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:bbox":"-18.2,65.56667,-18.0,65.76667",
     "lbl:latitude":65.66667,
     "lbl:longitude":-18.1,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
     "name:und_x_variant":[
@@ -50,7 +56,7 @@
     },
     "wof:country":"IS",
     "wof:created":1497042862,
-    "wof:geomhash":"6d943c1c5e707b624f674d5be68f1227",
+    "wof:geomhash":"59fd6be84cc8ceff0bc6f2e616fecb14",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -60,7 +66,7 @@
         }
     ],
     "wof:id":1125289573,
-    "wof:lastmodified":1566720486,
+    "wof:lastmodified":1696022867,
     "wof:name":"Akureyrarkaupsta\u00f0ur",
     "wof:parent_id":85672511,
     "wof:placetype":"localadmin",

--- a/data/112/534/416/3/1125344163.geojson
+++ b/data/112/534/416/3/1125344163.geojson
@@ -13,13 +13,19 @@
     "gn:fcode":"ADMD",
     "gn:population":0,
     "iso:country":"IS",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:bbox":"-21.6,63.85,-21.4,64.05",
     "lbl:latitude":63.95,
     "lbl:longitude":-21.5,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
     "name:und_x_variant":[
@@ -50,7 +56,7 @@
     },
     "wof:country":"IS",
     "wof:created":1497045824,
-    "wof:geomhash":"2d2776760f48607accdc502bfbe4dcd9",
+    "wof:geomhash":"f6d5cc4b9c68dd6ddd8fcd153c307ea6",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -60,7 +66,7 @@
         }
     ],
     "wof:id":1125344163,
-    "wof:lastmodified":1566720485,
+    "wof:lastmodified":1696022867,
     "wof:name":"Sveitarf\u00e9lagi\u00f0 \u00d6lfus",
     "wof:parent_id":85672519,
     "wof:placetype":"localadmin",

--- a/data/112/534/439/3/1125344393.geojson
+++ b/data/112/534/439/3/1125344393.geojson
@@ -13,13 +13,19 @@
     "gn:fcode":"ADMD",
     "gn:population":0,
     "iso:country":"IS",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:bbox":"-21.95,64.55,-21.75,64.75",
     "lbl:latitude":64.65,
     "lbl:longitude":-21.85,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
     "name:ceb_x_preferred":[
@@ -98,7 +104,7 @@
     },
     "wof:country":"IS",
     "wof:created":1497045841,
-    "wof:geomhash":"81c5517675c5e6be70ae8985311c96ea",
+    "wof:geomhash":"827497bbf47b63bed71e16d04cb5aa06",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -108,7 +114,7 @@
         }
     ],
     "wof:id":1125344393,
-    "wof:lastmodified":1566720485,
+    "wof:lastmodified":1696022867,
     "wof:name":"Borgarbygg\u00f0",
     "wof:parent_id":85672529,
     "wof:placetype":"localadmin",

--- a/data/112/534/440/1/1125344401.geojson
+++ b/data/112/534/440/1/1125344401.geojson
@@ -13,13 +13,19 @@
     "gn:fcode":"ADMD",
     "gn:population":0,
     "iso:country":"IS",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:bbox":"-20.43333,64.31667,-20.23333,64.51667",
     "lbl:latitude":64.41667,
     "lbl:longitude":-20.33333,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
     "name:cat_x_preferred":[
@@ -92,7 +98,7 @@
     },
     "wof:country":"IS",
     "wof:created":1497045841,
-    "wof:geomhash":"b6016ef4aab71a3c70d5b93e66c14f93",
+    "wof:geomhash":"157e1fcc667f0c1d51286490aca4a5d5",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -102,7 +108,7 @@
         }
     ],
     "wof:id":1125344401,
-    "wof:lastmodified":1566720485,
+    "wof:lastmodified":1696022867,
     "wof:name":"Bl\u00e1sk\u00f3gabygg\u00f0",
     "wof:parent_id":85672519,
     "wof:placetype":"localadmin",

--- a/data/112/537/731/1/1125377311.geojson
+++ b/data/112/537/731/1/1125377311.geojson
@@ -13,13 +13,19 @@
     "gn:fcode":"ADMD",
     "gn:population":0,
     "iso:country":"IS",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:bbox":"-22.15,63.73333,-21.95,63.93333",
     "lbl:latitude":63.83333,
     "lbl:longitude":-22.05,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
     "name:und_x_variant":[
@@ -46,7 +52,7 @@
     },
     "wof:country":"IS",
     "wof:created":1497047831,
-    "wof:geomhash":"b65016150345c331c1e011045c7ba0cf",
+    "wof:geomhash":"ccf021b04c0b2bc425431ea370c301dd",
     "wof:hierarchy":[
         {
             "continent_id":-1,
@@ -56,7 +62,7 @@
         }
     ],
     "wof:id":1125377311,
-    "wof:lastmodified":1566720487,
+    "wof:lastmodified":1696022867,
     "wof:name":"Hafnarfjar\u00f0arkaupsta\u00f0ur",
     "wof:parent_id":-1,
     "wof:placetype":"localadmin",

--- a/data/112/537/852/9/1125378529.geojson
+++ b/data/112/537/852/9/1125378529.geojson
@@ -13,13 +13,19 @@
     "gn:fcode":"ADMD",
     "gn:population":0,
     "iso:country":"IS",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:bbox":"-20.369,63.33877,-20.169,63.53877",
     "lbl:latitude":63.43877,
     "lbl:longitude":-20.269,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
     "name:deu_x_preferred":[
@@ -86,7 +92,7 @@
     },
     "wof:country":"IS",
     "wof:created":1497047902,
-    "wof:geomhash":"b40cae16a91f31a1b3ebe728e0385426",
+    "wof:geomhash":"685b99e193a2b753a06d5ead29519199",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -96,7 +102,7 @@
         }
     ],
     "wof:id":1125378529,
-    "wof:lastmodified":1566720487,
+    "wof:lastmodified":1696022867,
     "wof:name":"Vestmannaeyjab\u00e6r",
     "wof:parent_id":85672519,
     "wof:placetype":"localadmin",

--- a/data/112/538/636/5/1125386365.geojson
+++ b/data/112/538/636/5/1125386365.geojson
@@ -13,13 +13,19 @@
     "gn:fcode":"ADMD",
     "gn:population":0,
     "iso:country":"IS",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:bbox":"-18.26667,65.23333,-18.06667,65.43333",
     "lbl:latitude":65.33333,
     "lbl:longitude":-18.16667,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
     "name:ceb_x_preferred":[
@@ -95,7 +101,7 @@
     },
     "wof:country":"IS",
     "wof:created":1497048405,
-    "wof:geomhash":"eb6a3610b43a9d380357dc443c274aa1",
+    "wof:geomhash":"78de3cab808f65e1f024cf860505721a",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -105,7 +111,7 @@
         }
     ],
     "wof:id":1125386365,
-    "wof:lastmodified":1566720487,
+    "wof:lastmodified":1696022867,
     "wof:name":"Eyjafjar\u00f0arsveit",
     "wof:parent_id":85672511,
     "wof:placetype":"localadmin",

--- a/data/112/538/646/1/1125386461.geojson
+++ b/data/112/538/646/1/1125386461.geojson
@@ -13,13 +13,19 @@
     "gn:fcode":"ADMD",
     "gn:population":0,
     "iso:country":"IS",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:bbox":"-22.0,63.98333,-21.8,64.18333",
     "lbl:latitude":64.08333,
     "lbl:longitude":-21.9,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
     "name:bul_x_preferred":[
@@ -74,7 +80,7 @@
     },
     "wof:country":"IS",
     "wof:created":1497048412,
-    "wof:geomhash":"72460938be2921df673d8c9abbbf55b4",
+    "wof:geomhash":"2b15df4d29539d42d0bf2dbd88dfa762",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -84,7 +90,7 @@
         }
     ],
     "wof:id":1125386461,
-    "wof:lastmodified":1566720487,
+    "wof:lastmodified":1696022867,
     "wof:name":"K\u00f3pavogsb\u00e6r",
     "wof:parent_id":85672493,
     "wof:placetype":"localadmin",

--- a/data/112/538/752/3/1125387523.geojson
+++ b/data/112/538/752/3/1125387523.geojson
@@ -13,13 +13,19 @@
     "gn:fcode":"ADMD",
     "gn:population":0,
     "iso:country":"IS",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:bbox":"-21.1,63.78333,-20.9,63.98333",
     "lbl:latitude":63.88333,
     "lbl:longitude":-21.0,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
     "name:isl_x_preferred":[
@@ -50,7 +56,7 @@
     },
     "wof:country":"IS",
     "wof:created":1497048491,
-    "wof:geomhash":"2dc0b16d89972f02440396e90eb266d8",
+    "wof:geomhash":"5fb16feb67ed6206303a9731e96eb84d",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -60,7 +66,7 @@
         }
     ],
     "wof:id":1125387523,
-    "wof:lastmodified":1566720487,
+    "wof:lastmodified":1696022867,
     "wof:name":"Sveitarf\u00e9lagi\u00f0 \u00c1rborg",
     "wof:parent_id":85672519,
     "wof:placetype":"localadmin",

--- a/data/112/538/752/7/1125387527.geojson
+++ b/data/112/538/752/7/1125387527.geojson
@@ -13,13 +13,19 @@
     "gn:fcode":"ADMD",
     "gn:population":0,
     "iso:country":"IS",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:bbox":"-22.76667,63.81667,-22.56667,64.01667",
     "lbl:latitude":63.91667,
     "lbl:longitude":-22.66667,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
     "name:ara_x_preferred":[
@@ -143,7 +149,7 @@
     },
     "wof:country":"IS",
     "wof:created":1497048491,
-    "wof:geomhash":"ec85f97a3cbd26495c15cf31e7905490",
+    "wof:geomhash":"1906d458b3f6075a09bb78ad9fe22b8e",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -153,7 +159,7 @@
         }
     ],
     "wof:id":1125387527,
-    "wof:lastmodified":1566720487,
+    "wof:lastmodified":1696022867,
     "wof:name":"Reykjanesb\u00e6r",
     "wof:parent_id":85672515,
     "wof:placetype":"localadmin",

--- a/data/112/541/287/7/1125412877.geojson
+++ b/data/112/541/287/7/1125412877.geojson
@@ -13,13 +13,19 @@
     "gn:fcode":"ADMD",
     "gn:population":0,
     "iso:country":"IS",
+    "label:eng_x_preferred_placetype":[
+        "municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "lbl:bbox":"-18.85,65.98333,-18.65,66.18333",
     "lbl:latitude":66.08333,
     "lbl:longitude":-18.75,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
     "name:und_x_variant":[
@@ -50,7 +56,7 @@
     },
     "wof:country":"IS",
     "wof:created":1497050734,
-    "wof:geomhash":"ac5b783abeeaa25736e61b3bb6e2e5b5",
+    "wof:geomhash":"5f3322bb93c6567893d6a4363d4bfe6d",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -60,7 +66,7 @@
         }
     ],
     "wof:id":1125412877,
-    "wof:lastmodified":1566720489,
+    "wof:lastmodified":1696022867,
     "wof:name":"\u00d3lafsfjar\u00f0arb\u00e6r",
     "wof:parent_id":85672511,
     "wof:placetype":"localadmin",

--- a/data/856/332/49/85633249.geojson
+++ b/data/856/332/49/85633249.geojson
@@ -1312,6 +1312,7 @@
         "hasc:id":"IS",
         "icao:code":"TF",
         "ioc:id":"ISL",
+        "iso:code":"IS",
         "itu:id":"ISL",
         "m49:code":"352",
         "marc:id":"ic",
@@ -1325,6 +1326,7 @@
         "wk:page":"Iceland",
         "wmo:id":"IL"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IS",
     "wof:country_alpha3":"ISL",
     "wof:geom_alt":[
@@ -1346,7 +1348,7 @@
     "wof:lang_x_spoken":[
         "isl"
     ],
-    "wof:lastmodified":1694492262,
+    "wof:lastmodified":1695881375,
     "wof:name":"Iceland",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/856/724/93/85672493.geojson
+++ b/data/856/724/93/85672493.geojson
@@ -334,9 +334,11 @@
         "gn:id":3426182,
         "gp:id":-99,
         "hasc:id":"IS.HO",
+        "iso:code":"IS-1",
         "unlc:id":"IS-0",
         "wd:id":"Q203304"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IS",
     "wof:geomhash":"5ce9086c3bf31398d7fc0924e14f453d",
     "wof:hierarchy":[
@@ -353,7 +355,7 @@
     "wof:lang_x_spoken":[
         "isl"
     ],
-    "wof:lastmodified":1694639832,
+    "wof:lastmodified":1695884505,
     "wof:name":"Reykjav\u00edk",
     "wof:parent_id":85633249,
     "wof:placetype":"region",

--- a/data/856/724/97/85672497.geojson
+++ b/data/856/724/97/85672497.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.882971,
-    "geom:area_square_m":9538057300.219376,
+    "geom:area_square_m":9538059102.969933,
     "geom:bbox":"-24.539906,64.972365,-20.984217,66.466986",
     "geom:latitude":65.816536,
     "geom:longitude":-22.576912,
@@ -346,12 +346,14 @@
         "gn:id":3426185,
         "gp:id":-99,
         "hasc:id":"IS.VF",
+        "iso:code":"IS-4",
         "iso:id":"IS-4",
         "unlc:id":"IS-4",
         "wd:id":"Q727267"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IS",
-    "wof:geomhash":"bf21959f850dafe5ac4d0436016b237d",
+    "wof:geomhash":"afaef2d6acd4661d67c46b601ee0931d",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -366,7 +368,7 @@
     "wof:lang_x_spoken":[
         "isl"
     ],
-    "wof:lastmodified":1690934625,
+    "wof:lastmodified":1695884329,
     "wof:name":"Vestfir\u00f0ir",
     "wof:parent_id":85633249,
     "wof:placetype":"region",

--- a/data/856/725/01/85672501.geojson
+++ b/data/856/725/01/85672501.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.061121,
-    "geom:area_square_m":21303275618.151974,
+    "geom:area_square_m":21303272167.297333,
     "geom:bbox":"-17.387538,63.772992,-13.502919,65.986274",
     "geom:latitude":64.895248,
     "geom:longitude":-15.395096,
@@ -350,12 +350,14 @@
         "gn:id":3337405,
         "gp:id":2345698,
         "hasc:id":"IS.AL",
+        "iso:code":"IS-7",
         "iso:id":"IS-7",
         "unlc:id":"IS-7",
         "wd:id":"Q220663"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IS",
-    "wof:geomhash":"d68374b59c41af760cb82785eb9e3d77",
+    "wof:geomhash":"38c2a403be2fe43a0c4ed903091b2c91",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -370,7 +372,7 @@
     "wof:lang_x_spoken":[
         "isl"
     ],
-    "wof:lastmodified":1690934624,
+    "wof:lastmodified":1695885134,
     "wof:name":"Austurland",
     "wof:parent_id":85633249,
     "wof:placetype":"region",

--- a/data/856/725/07/85672507.geojson
+++ b/data/856/725/07/85672507.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.428538,
-    "geom:area_square_m":12517795634.381029,
+    "geom:area_square_m":12517794883.574173,
     "geom:bbox":"-21.119944,64.750053,-18.351174,66.157993",
     "geom:latitude":65.36365,
     "geom:longitude":-19.701187,
@@ -346,12 +346,14 @@
         "gn:id":3337403,
         "gp:id":-99,
         "hasc:id":"IS.NV",
+        "iso:code":"IS-5",
         "iso:id":"IS-5",
         "unlc:id":"IS-5",
         "wd:id":"Q210866"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IS",
-    "wof:geomhash":"e8c1acbe559ec9ad6b824eedfc685659",
+    "wof:geomhash":"f015fc285c75a9e6943e64c87351ef94",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -366,7 +368,7 @@
     "wof:lang_x_spoken":[
         "isl"
     ],
-    "wof:lastmodified":1690934624,
+    "wof:lastmodified":1695884329,
     "wof:name":"Nor\u00f0urland vestra",
     "wof:parent_id":85633249,
     "wof:placetype":"region",

--- a/data/856/725/11/85672511.geojson
+++ b/data/856/725/11/85672511.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.341871,
-    "geom:area_square_m":22200112103.616276,
+    "geom:area_square_m":22200113591.889286,
     "geom:bbox":"-19.078765,64.471956,-14.563629,66.564154",
     "geom:latitude":65.574686,
     "geom:longitude":-17.069983,
@@ -355,12 +355,14 @@
         "gn:id":3337404,
         "gp:id":-99,
         "hasc:id":"IS.NE",
+        "iso:code":"IS-6",
         "iso:id":"IS-6",
         "unlc:id":"IS-6",
         "wd:id":"Q241551"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IS",
-    "wof:geomhash":"da811561b1015390deb48376ed883708",
+    "wof:geomhash":"bce10e232a592c67299fcf72b8fbaf4d",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -375,7 +377,7 @@
     "wof:lang_x_spoken":[
         "isl"
     ],
-    "wof:lastmodified":1690934623,
+    "wof:lastmodified":1695884329,
     "wof:name":"Nor\u00f0urland eystra",
     "wof:parent_id":85633249,
     "wof:placetype":"region",

--- a/data/856/725/15/85672515.geojson
+++ b/data/856/725/15/85672515.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.161287,
-    "geom:area_square_m":876333743.06611,
+    "geom:area_square_m":876333776.993902,
     "geom:bbox":"-22.736806,63.809149,-21.652394,64.089748",
     "geom:latitude":63.935662,
     "geom:longitude":-22.278087,
@@ -342,12 +342,14 @@
         "gn:id":3426183,
         "gp:id":-99,
         "hasc:id":"IS.SU",
+        "iso:code":"IS-2",
         "iso:id":"IS-2",
         "unlc:id":"IS-2",
         "wd:id":"Q212768"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IS",
-    "wof:geomhash":"23d10fa257eb3d846f5897e5e12f4f1b",
+    "wof:geomhash":"986d30ce46714945411e880bf0140bce",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -362,7 +364,7 @@
     "wof:lang_x_spoken":[
         "isl"
     ],
-    "wof:lastmodified":1690934624,
+    "wof:lastmodified":1695884329,
     "wof:name":"Su\u00f0urnes",
     "wof:parent_id":85633249,
     "wof:placetype":"region",

--- a/data/856/725/19/85672519.geojson
+++ b/data/856/725/19/85672519.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.601298,
-    "geom:area_square_m":24811178583.19072,
+    "geom:area_square_m":24811178952.045338,
     "geom:bbox":"-21.931976,63.295315,-16.876613,64.880614",
     "geom:latitude":64.146441,
     "geom:longitude":-19.176963,
@@ -345,12 +345,14 @@
         "gn:id":3337406,
         "gp:id":-99,
         "hasc:id":"IS.SL",
+        "iso:code":"IS-8",
         "iso:id":"IS-8",
         "unlc:id":"IS-8",
         "wd:id":"Q204796"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IS",
-    "wof:geomhash":"87ef891d01e9bcf28690e7eb61e44cb6",
+    "wof:geomhash":"423f5a66f6ec2f9eee6ec56cb85b48b4",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -365,7 +367,7 @@
     "wof:lang_x_spoken":[
         "isl"
     ],
-    "wof:lastmodified":1690934624,
+    "wof:lastmodified":1695884329,
     "wof:name":"Su\u00f0urland",
     "wof:parent_id":85633249,
     "wof:placetype":"region",

--- a/data/856/725/25/85672525.geojson
+++ b/data/856/725/25/85672525.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.114197,
-    "geom:area_square_m":613966733.934425,
+    "geom:area_square_m":613967072.754884,
     "geom:bbox":"-21.9303,63.999401,-21.143433,64.398989",
     "geom:latitude":64.229182,
     "geom:longitude":-21.53658,
@@ -346,11 +346,13 @@
         "gn:id":3426182,
         "gp:id":-99,
         "hasc:id":"IS.HO",
+        "iso:code":"IS-1",
         "iso:id":"IS-1",
         "wd:id":"Q203304"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IS",
-    "wof:geomhash":"1f249c75a5270836fdac10e44c613091",
+    "wof:geomhash":"e67736b6dd8052f554448ae7b830e941",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -365,7 +367,7 @@
     "wof:lang_x_spoken":[
         "isl"
     ],
-    "wof:lastmodified":1690934625,
+    "wof:lastmodified":1695884505,
     "wof:name":"H\u00f6fu\u00f0borgarsv\u00e6\u00f0i",
     "wof:parent_id":85633249,
     "wof:placetype":"region",

--- a/data/856/725/29/85672529.geojson
+++ b/data/856/725/29/85672529.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.81737,
-    "geom:area_square_m":9552176612.598717,
+    "geom:area_square_m":9552174363.13014,
     "geom:bbox":"-24.060048,64.297309,-19.792688,65.501842",
     "geom:latitude":64.845028,
     "geom:longitude":-21.704744,
@@ -347,12 +347,14 @@
         "gn:id":3426184,
         "gp:id":-99,
         "hasc:id":"IS.VL",
+        "iso:code":"IS-3",
         "iso:id":"IS-3",
         "unlc:id":"IS-3",
         "wd:id":"Q221791"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IS",
-    "wof:geomhash":"b739d9c1e221028a875e41212711b3d1",
+    "wof:geomhash":"02d42f963f23e3ec2085d31cc16f1488",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -367,7 +369,7 @@
     "wof:lang_x_spoken":[
         "isl"
     ],
-    "wof:lastmodified":1690934623,
+    "wof:lastmodified":1695884795,
     "wof:name":"Vesturland",
     "wof:parent_id":85633249,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.